### PR TITLE
Fix date serializer

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -37,9 +37,14 @@ class ResourceMixin {
         if (typeof field === 'object' && field !== null && 'serialize' in field) {
           serialized[attr] = field.serialize();
         } else {
-          serialized[attr] = field;
+          if (typeof field === 'object' && field !== null && (attr === 'postDate' || attr === 'transactionDate')) {
+            serialized[attr] = field.toISOString();
+          } else {
+            serialized[attr] = field;
+          }
         }
       }
+
     });
     return invertedFieldsubs.reduce(renameProperties, serialized);
   }


### PR DESCRIPTION
This PR changes the library behaviour, so it might break apps using it.

Before a `Movement` serialized like this:
```{
amount: 7844717
currency: "CLP"
description: "Nihil aspernatur dignissimos est."
id: "mov_ZxENnDHvJAxreJkK"
postDate: {}
transactionDate: null
}
```

`postDate` and `transactionDate`, if not null, are serialized as empty objects.

Now a `Movement` is serialized like this:
```{
amount: 7844717
currency: "CLP"
description: "Nihil aspernatur dignissimos est."
id: "mov_ZxENnDHvJAxreJkK"
postDate: "2021-05-11T00:00:00.000Z"
transactionDate: null
}
```
`postDate` and `transactionDate`, if not null, are serialized as strings.
