### PR TITLE
Fix npm auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node.js v14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
+          registry-url: https://registry.npmjs.org
 
       # Cache the node_modules directory
       - name: Set up node_modules cache
@@ -34,7 +35,7 @@ jobs:
       - name: Publish the package
         run: npm publish
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   github-release:
     needs: npm-release


### PR DESCRIPTION
## Description

Change the environmental variable's name that contained the NPM token. Also, setup the exact registry to use to publish the package. I used [these](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) instructions, but I think that it may fail (because `NODE_AUTH_TOKEN` won't be set on the environment for the `yarn build` command). If it fails, I will change the `NODE_AUTH_TOKEN` to be an environmental variable to the complete workflow instead of just a step (I would prefer to avoid this, just to reduce the amount of times that the token will be exposed to as little as possible).

## Requirements

None.

## Additional changes

Update the version of the GitHub Action that sets up Node.