### PR TITLE
Fix `get` requests error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,13 +43,3 @@ jobs:
 
       - name: Test using Ava
         run: yarn test
-
-      - name: Generate coverage report
-        run: yarn cov
-
-      - name: Upload coverage
-        uses: codecov/codecov-action@v2
-        with:
-          files: coverage/cobertura-coverage.xml
-          fail_ci_if_error: true
-          verbose: true

--- a/README.md
+++ b/README.md
@@ -12,15 +12,11 @@
 </a>
 
 <a href="https://github.com/fintoc-com/fintoc-node/actions?query=workflow%3Atests" target="_blank">
-    <img src="https://img.shields.io/github/workflow/status/fintoc-com/fintoc-node/tests?label=tests&logo=nodedotjs&logoColor=%23fff" alt="Tests">
-</a>
-
-<a href="https://codecov.io/gh/fintoc-com/fintoc-node" target="_blank">
-    <img src="https://img.shields.io/codecov/c/gh/fintoc-com/fintoc-node?label=coverage&logo=codecov&logoColor=ffffff" alt="Coverage">
+    <img src="https://img.shields.io/github/actions/workflow/status/fintoc-com/fintoc-node/tests.yml?branch=master&label=tests&logo=nodedotjs&logoColor=%23fff" alt="Tests">
 </a>
 
 <a href="https://github.com/fintoc-com/fintoc-node/actions?query=workflow%3Alinters" target="_blank">
-    <img src="https://img.shields.io/github/workflow/status/fintoc-com/fintoc-node/linters?label=linters&logo=github" alt="Linters">
+    <img src="https://img.shields.io/github/actions/workflow/status/fintoc-com/fintoc-node/linters.yml?branch=master&label=linters&logo=github" alt="Tests">
 </a>
 </p>
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -50,7 +50,7 @@ export class Client {
     options: IRequestOptions,
   ): Promise<Record<string, string> | AsyncGenerator<Record<string, string>, void, unknown>> {
     const {
-      path, paginated = false, method = 'get', params = {}, json = {},
+      path, json, paginated = false, method = 'get', params = {},
     } = options;
     if (paginated) {
       return paginate({


### PR DESCRIPTION
## Description

Some `get` requests were failing due to the `data` being passed by default as an empty object (but `get` requests shouldn't receive `data`). Now, `data` defaults to `undefined`  instead of an empty object.

## Requirements

None.

## Additional changes

None.
