### PR TITLE
Convert axios client to singleton pattern

### DIFF
--- a/src/interfaces/paginator/paginationOptions.ts
+++ b/src/interfaces/paginator/paginationOptions.ts
@@ -3,5 +3,6 @@ import { AxiosInstance } from 'axios';
 export interface IPaginationOptions {
   client: AxiosInstance,
   path: string,
+  headers: Record<string, string>,
   params?: Record<string, string>
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,7 +7,7 @@ import { IRequestOptions } from '../interfaces/client/requestOptions';
 import { paginate } from './paginator';
 
 export class Client {
-  #client?: AxiosInstance;
+  static #client?: AxiosInstance;
 
   baseUrl: string;
   apiKey: string;
@@ -22,18 +22,17 @@ export class Client {
     this.apiKey = apiKey;
     this.userAgent = userAgent;
     this.params = params || {};
-    this.#client = undefined;
   }
 
   private get client() {
-    if (this.#client === undefined) {
-      this.#client = axios.create({
+    if (Client.#client === undefined) {
+      Client.#client = axios.create({
         baseURL: this.baseUrl,
         headers: this.headers,
         params: this.params,
       });
     }
-    return this.#client;
+    return Client.#client;
   }
 
   get headers() {
@@ -52,15 +51,18 @@ export class Client {
     const {
       path, json, paginated = false, method = 'get', params = {},
     } = options;
+    const url = `${this.baseUrl}${path}`;
+    const allParams = { ...this.params, ...params };
     if (paginated) {
       return paginate({
         client: this.client,
-        path,
-        params,
+        path: url,
+        headers: this.headers,
+        params: allParams,
       });
     }
     const response = await this.client.request({
-      method, url: path, params, data: json,
+      method, url, params: allParams, data: json, headers: this.headers,
     });
     return response.data;
   }

--- a/src/lib/mixins/managerMixin.ts
+++ b/src/lib/mixins/managerMixin.ts
@@ -15,7 +15,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
 
   constructor(path: string, client: Client) {
     this.#path = path;
-    this._client = client.extend();
+    this._client = client;
     this.#handlers = {
       update: this.postUpdateHandler.bind(this),
       delete: this.postDeleteHandler.bind(this),

--- a/src/lib/mixins/resourceMixin.ts
+++ b/src/lib/mixins/resourceMixin.ts
@@ -68,7 +68,6 @@ export abstract class ResourceMixin<ResourceType> {
       }
       /* eslint-enable no-await-in-loop */
     }
-    // console.log(content);
     // @ts-ignore: cannot create an instance of an abstract class
     return new this(client, handlers, methods, path, content);
   }
@@ -145,7 +144,7 @@ export abstract class ResourceMixin<ResourceType> {
     await resourceDelete(
       this._client,
       this.#path,
-      this.id,
+      identifier,
       innerArgs,
     );
     return this.#handlers.delete(identifier, innerArgs);

--- a/src/lib/paginator.ts
+++ b/src/lib/paginator.ts
@@ -38,23 +38,31 @@ export function parseLinkHeaders(
 }
 
 export async function request(options: IPaginationOptions) {
-  const { client, path, params = {} } = options;
-  const response = await client.request<Array<Record<string, any>>>({ method: 'get', url: path, params: params || {} });
-  const headers = parseLinkHeaders(response.headers.link);
-  const next = headers && headers.next;
+  const {
+    client, path, headers, params = {},
+  } = options;
+  const response = await client.request<Array<Record<string, any>>>({
+    method: 'get', url: path, params: params || {}, headers,
+  });
+  const responseHeaders = parseLinkHeaders(response.headers.link);
+  const next = responseHeaders && responseHeaders.next;
   const elements = response.data;
   return { next, elements };
 }
 
 export async function* paginate(options: IPaginationOptions) {
-  const { client, path, params = {} } = options;
-  let response = await request({ client, path, params });
+  const {
+    client, path, headers, params = {},
+  } = options;
+  let response = await request({
+    client, path, headers, params,
+  });
   /* eslint-disable no-await-in-loop */
   for (const element of response.elements) {
     yield element;
   }
   while (response.next) {
-    response = await request({ client, path: response.next });
+    response = await request({ client, path: response.next, headers });
     for (const element of response.elements) {
       yield element;
     }

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -28,7 +28,7 @@ test('fintoc.paymentIntents.all()', async (t) => {
   for await (const paymentIntent of paymentIntents) {
     count += 1;
     t.is(paymentIntent.method, 'get');
-    t.is(paymentIntent.url, 'payment_intents');
+    t.is(paymentIntent.url, 'v1/payment_intents');
   }
 
   t.true(count > 0);
@@ -40,7 +40,7 @@ test('fintoc.paymentIntents.get()', async (t) => {
   const paymentIntent = await ctx.fintoc.paymentIntents.get(paymentId);
 
   t.is(paymentIntent.method, 'get');
-  t.is(paymentIntent.url, `payment_intents/${paymentId}`);
+  t.is(paymentIntent.url, `v1/payment_intents/${paymentId}`);
 });
 
 test('fintoc.paymentIntents.create()', async (t) => {
@@ -53,7 +53,7 @@ test('fintoc.paymentIntents.create()', async (t) => {
   const paymentIntent = await ctx.fintoc.paymentIntents.create(paymentData);
 
   t.is(paymentIntent.method, 'post');
-  t.is(paymentIntent.url, 'payment_intents');
+  t.is(paymentIntent.url, 'v1/payment_intents');
   t.is(paymentIntent.json.amount, paymentData.amount);
   t.is(paymentIntent.json.currency, paymentData.currency);
   t.is(paymentIntent.json.payment_method, paymentData.payment_method);
@@ -67,7 +67,7 @@ test('fintoc.links.all()', async (t) => {
   for await (const link of links) {
     count += 1;
     t.is(link.method, 'get');
-    t.is(link.url, 'links');
+    t.is(link.url, 'v1/links');
   }
 
   t.true(count > 0);
@@ -79,7 +79,7 @@ test('fintoc.links.get()', async (t) => {
   const link = await ctx.fintoc.links.get(linkToken);
 
   t.is(link.method, 'get');
-  t.is(link.url, `links/${linkToken}`);
+  t.is(link.url, `v1/links/${linkToken}`);
 });
 
 test('fintoc.links.update()', async (t) => {
@@ -91,7 +91,7 @@ test('fintoc.links.update()', async (t) => {
   const link = await ctx.fintoc.links.update(linkToken, updateData);
 
   t.is(link.method, 'patch');
-  t.is(link.url, `links/${linkToken}`);
+  t.is(link.url, `v1/links/${linkToken}`);
   t.is(link.json.username, updateData.username);
 });
 
@@ -116,7 +116,7 @@ test('link.accounts.all()', async (t) => {
   for await (const account of accounts) {
     count += 1;
     t.is(account.method, 'get');
-    t.is(account.url, 'accounts');
+    t.is(account.url, 'v1/accounts');
   }
 
   t.true(count > 0);
@@ -131,7 +131,7 @@ test('link.accounts.get()', async (t) => {
   const account = await link.accounts.get(accountId);
 
   t.is(account.method, 'get');
-  t.is(account.url, `accounts/${accountId}`);
+  t.is(account.url, `v1/accounts/${accountId}`);
 
   t.is(link.accounts._client.params.link_token, linkToken);
   t.is(account._client.params.link_token, linkToken);
@@ -153,7 +153,7 @@ test('account.movements.all()', async (t) => {
   for await (const movement of movements) {
     count += 1;
     t.is(movement.method, 'get');
-    t.is(movement.url, `accounts/${accountId}/movements`);
+    t.is(movement.url, `v1/accounts/${accountId}/movements`);
     t.is(movement._client.params.link_token, linkToken);
   }
 
@@ -172,7 +172,7 @@ test('account.movements.get()', async (t) => {
   const movement = await account.movements.get(movementId);
 
   t.is(movement.method, 'get');
-  t.is(movement.url, `accounts/${accountId}/movements/${movementId}`);
+  t.is(movement.url, `v1/accounts/${accountId}/movements/${movementId}`);
   t.is(movement._client.params.link_token, linkToken);
 });
 
@@ -184,7 +184,7 @@ test('fintoc.webhookEndpoints.all()', async (t) => {
   for await (const webhookEndpoint of webhookEndpoints) {
     count += 1;
     t.is(webhookEndpoint.method, 'get');
-    t.is(webhookEndpoint.url, 'webhook_endpoints');
+    t.is(webhookEndpoint.url, 'v1/webhook_endpoints');
   }
 
   t.true(count > 0);
@@ -196,7 +196,7 @@ test('fintoc.webhookEndpoints.get()', async (t) => {
   const webhookEndpoint = await ctx.fintoc.webhookEndpoints.get(webhookEndpointId);
 
   t.is(webhookEndpoint.method, 'get');
-  t.is(webhookEndpoint.url, `webhook_endpoints/${webhookEndpointId}`);
+  t.is(webhookEndpoint.url, `v1/webhook_endpoints/${webhookEndpointId}`);
 });
 
 test('fintoc.webhookEndpoints.create()', async (t) => {
@@ -208,7 +208,7 @@ test('fintoc.webhookEndpoints.create()', async (t) => {
   const webhookEndpoint = await ctx.fintoc.webhookEndpoints.create(webhookData);
 
   t.is(webhookEndpoint.method, 'post');
-  t.is(webhookEndpoint.url, 'webhook_endpoints');
+  t.is(webhookEndpoint.url, 'v1/webhook_endpoints');
   t.is(webhookEndpoint.json.url, webhookData.url);
   t.deepEqual(webhookEndpoint.json.enabled_events, webhookData.enabled_events);
 });
@@ -222,7 +222,7 @@ test('fintoc.webhookEndpoints.update()', async (t) => {
   const webhookEndpoint = await ctx.fintoc.webhookEndpoints.update(webhookEndpointId, updateData);
 
   t.is(webhookEndpoint.method, 'patch');
-  t.is(webhookEndpoint.url, `webhook_endpoints/${webhookEndpointId}`);
+  t.is(webhookEndpoint.url, `v1/webhook_endpoints/${webhookEndpointId}`);
   t.deepEqual(webhookEndpoint.json.enabled_events, updateData.enabled_events);
 });
 

--- a/src/spec/mocks/client/response.ts
+++ b/src/spec/mocks/client/response.ts
@@ -43,8 +43,8 @@ export class MockResponse {
     }
 
     const urlParts = this.url.split('/');
-    const hasIdentifier = urlParts.length > 1 && urlParts[1];
-    const id = hasIdentifier ? urlParts[1] : 'idx';
+    const hasIdentifier = urlParts.length > 2 && urlParts[2];
+    const id = hasIdentifier ? urlParts[2] : 'idx';
     return {
       id,
       method: this.method,

--- a/src/spec/paginator/paginate.spec.ts
+++ b/src/spec/paginator/paginate.spec.ts
@@ -17,7 +17,7 @@ test.after((t) => {
 
 test('"Paginate" pagination', async (t) => {
   const client = axios.create({ baseURL: 'https://test.com' });
-  const data = paginate({ client, path: '/movements' });
+  const data = paginate({ client, path: '/movements', headers: {} });
 
   t.assert(isAsyncGenerator(data));
 

--- a/src/spec/paginator/request.spec.ts
+++ b/src/spec/paginator/request.spec.ts
@@ -16,7 +16,7 @@ test.after((t) => {
 
 test('"Request" request response', async (t) => {
   const client = axios.create({ baseURL: 'https://test.com' });
-  const data = await request({ client, path: '/movements' });
+  const data = await request({ client, path: '/movements', headers: {} });
 
   t.assert('next' in data);
   t.assert('elements' in data);
@@ -25,7 +25,9 @@ test('"Request" request response', async (t) => {
 
 test('"Request" request params get passed to next URL', async (t) => {
   const client = axios.create({ baseURL: 'https://test.com' });
-  const data = await request({ client, path: '/movements', params: { link_token: 'sample_link_token' } });
+  const data = await request({
+    client, path: '/movements', headers: {}, params: { link_token: 'sample_link_token' },
+  });
 
   t.assert('next' in data);
   t.assert(data.next && data.next.includes('link_token=sample_link_token'));


### PR DESCRIPTION
## Description

This pull request converts the Axios client to a singleton pattern. Previously, each manager instance and Link resource created its own Axios client, resulting in multiple client instances throughout the SDK and unnecessary memory overhead.

With this change, the SDK now uses a single shared Axios client instance across all managers and resources, reducing memory usage and improving performance.

## Requirements

None.

## Additional changes

None.
