### PR TITLE
Add transfers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/core';
 export { WebhookSignature } from './lib/webhook';
 export { WebhookSignatureError } from './lib/errors';
+export { JWSSignature } from './lib/jws';

--- a/src/interfaces/client/constructorOptions.ts
+++ b/src/interfaces/client/constructorOptions.ts
@@ -3,4 +3,5 @@ export interface IConstructorOptions {
   apiKey: string,
   userAgent: string,
   params?: Record<string, string>,
+  jwsPrivateKey?: string | Buffer,
 }

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,5 +1,6 @@
+/* eslint-disable max-classes-per-file */
 import { Client } from './client';
-import { API_BASE_URL, API_VERSION } from './constants';
+import { API_BASE_URL } from './constants';
 import {
   AccountsManager,
   InvoicesManager,
@@ -10,7 +11,27 @@ import {
   TaxReturnsManager,
   WebhookEndpointsManager,
 } from './managers';
+import {
+  AccountNumbersManager,
+  SimulateManager,
+  TransfersManager,
+  AccountsManager as V2AccountsManager,
+} from './managers/v2';
 import { version } from './version';
+
+class FintocV2 {
+  accounts: V2AccountsManager;
+  transfers: TransfersManager;
+  accountNumbers: AccountNumbersManager;
+  simulate: SimulateManager;
+
+  constructor(client: Client) {
+    this.accounts = new V2AccountsManager('/v2/accounts', client);
+    this.transfers = new TransfersManager('/v2/transfers', client);
+    this.accountNumbers = new AccountNumbersManager('/v2/account_numbers', client);
+    this.simulate = new SimulateManager('/v2/simulate', client);
+  }
+}
 
 export class Fintoc {
   #client: Client;
@@ -23,20 +44,24 @@ export class Fintoc {
   subscriptions: SubscriptionsManager;
   taxReturns: TaxReturnsManager;
   webhookEndpoints: WebhookEndpointsManager;
+  v2: FintocV2;
 
-  constructor(apiKey: string) {
+  constructor(apiKey: string, jwsPrivateKey?: string) {
     this.#client = new Client({
-      baseUrl: `${API_BASE_URL}/${API_VERSION}`,
+      baseUrl: `${API_BASE_URL}`,
       userAgent: `fintoc-node/${version}`,
       apiKey,
+      jwsPrivateKey,
     });
-    this.accounts = new AccountsManager('/accounts', this.#client);
-    this.invoices = new InvoicesManager('/invoices', this.#client);
-    this.links = new LinksManager('/links', this.#client);
-    this.paymentIntents = new PaymentIntentsManager('/payment_intents', this.#client);
-    this.refreshIntents = new RefreshIntentsManager('/refresh_intents', this.#client);
-    this.subscriptions = new SubscriptionsManager('/subscriptions', this.#client);
-    this.taxReturns = new TaxReturnsManager('/tax_returns', this.#client);
-    this.webhookEndpoints = new WebhookEndpointsManager('/webhook_endpoints', this.#client);
+    this.accounts = new AccountsManager('/v1/accounts', this.#client);
+    this.invoices = new InvoicesManager('/v1/invoices', this.#client);
+    this.links = new LinksManager('/v1/links', this.#client);
+    this.paymentIntents = new PaymentIntentsManager('/v1/payment_intents', this.#client);
+    this.refreshIntents = new RefreshIntentsManager('/v1/refresh_intents', this.#client);
+    this.subscriptions = new SubscriptionsManager('/v1/subscriptions', this.#client);
+    this.taxReturns = new TaxReturnsManager('/v1/tax_returns', this.#client);
+    this.webhookEndpoints = new WebhookEndpointsManager('/v1/webhook_endpoints', this.#client);
+
+    this.v2 = new FintocV2(this.#client);
   }
 }

--- a/src/lib/jws.ts
+++ b/src/lib/jws.ts
@@ -1,0 +1,106 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+
+/**
+ * Class to handle JWS signature generation for Fintoc API requests.
+ */
+export class JWSSignature {
+  private privateKey: crypto.KeyObject;
+
+  /**
+   * Create a new JWSSignature instance with a private key.
+   *
+   * @param privateKey - The private key in one of these formats:
+   *   - String containing PEM-formatted key
+   *   - Buffer containing PEM-formatted key
+   *   - String path to a PEM key file
+   */
+  constructor(privateKey: string | Buffer) {
+    this.privateKey = JWSSignature.loadPrivateKey(privateKey);
+  }
+
+  /**
+   * Generate a JWS signature header for the given payload
+   * @param rawBody - The request body as a string
+   * @returns The JWS signature header to be used in 'Fintoc-JWS-Signature' header.
+   */
+  public generateHeader(rawBody: string): string {
+    const headers = {
+      alg: 'RS256',
+      nonce: JWSSignature.generateNonce(),
+      ts: Math.floor(Date.now() / 1000),
+      crit: ['ts', 'nonce'],
+    };
+
+    const protectedBase64 = Buffer.from(JSON.stringify(headers)).toString('base64url');
+    const payloadBase64 = Buffer.from(rawBody).toString('base64url');
+    const signingInput = `${protectedBase64}.${payloadBase64}`;
+
+    const signature = this.createSignature(signingInput);
+    const signatureBase64 = Buffer.from(signature).toString('base64url');
+
+    return `${protectedBase64}.${signatureBase64}`;
+  }
+
+  private static loadPrivateKey(keyInput: string | Buffer): crypto.KeyObject {
+    let keyMaterial: string | Buffer;
+
+    if (Buffer.isBuffer(keyInput)) {
+      keyMaterial = keyInput;
+    } else if (typeof keyInput === 'string') {
+      if (JWSSignature.isFilePath(keyInput)) {
+        try {
+          keyMaterial = fs.readFileSync(keyInput, 'utf8');
+        } catch (error) {
+          throw new Error(`Failed to read private key file: ${keyInput}. ${error}`);
+        }
+      } else {
+        keyMaterial = keyInput;
+      }
+    } else {
+      throw new Error('Private key must be a string (PEM content or file path) or Buffer');
+    }
+
+    try {
+      return crypto.createPrivateKey(keyMaterial);
+    } catch (error) {
+      throw new Error(`Invalid private key format: ${error}`);
+    }
+  }
+
+  private static isFilePath(input: string): boolean {
+    if (!input || typeof input !== 'string') {
+      return false;
+    }
+
+    const trimmedInput = input.trim();
+
+    if (trimmedInput.includes('-----BEGIN') && trimmedInput.includes('-----END')) {
+      return false;
+    }
+
+    if (trimmedInput.includes('\n') || trimmedInput.includes('\r')) {
+      return false;
+    }
+
+    if (trimmedInput.length > 1000) {
+      return false;
+    }
+
+    const hasPathSeparators = trimmedInput.includes('/') || trimmedInput.includes('\\');
+    const hasFileExtension = /\.[a-zA-Z0-9]{1,10}$/.test(trimmedInput);
+    const looksLikeAbsolutePath = /^\/|^[a-zA-Z]:[\\\\//]|^~/.test(trimmedInput);
+
+    return hasPathSeparators || (hasFileExtension && looksLikeAbsolutePath);
+  }
+
+  private static generateNonce(): string {
+    return crypto.randomBytes(16).toString('hex');
+  }
+
+  private createSignature(data: string): Buffer {
+    return crypto.createSign('sha256')
+      .update(data)
+      .sign({ key: this.privateKey, padding: crypto.constants.RSA_PKCS1_PADDING });
+  }
+}

--- a/src/lib/managers/accountsManager.ts
+++ b/src/lib/managers/accountsManager.ts
@@ -12,6 +12,6 @@ export class AccountsManager extends ManagerMixin<Account> {
 
   constructor(path: string, client: Client) {
     super(path, client);
-    this.movements = new MovementsManager('/accounts/{account_id}/movements', client);
+    this.movements = new MovementsManager('/v1/accounts/{account_id}/movements', client);
   }
 }

--- a/src/lib/managers/v2/accountNumbersManager.ts
+++ b/src/lib/managers/v2/accountNumbersManager.ts
@@ -1,0 +1,7 @@
+import { ManagerMixin } from '../../mixins';
+import { AccountNumber } from '../../resources/v2/accountNumber';
+
+export class AccountNumbersManager extends ManagerMixin<AccountNumber> {
+  static resource = 'account_number';
+  static methods = ['all', 'get', 'create', 'update'];
+}

--- a/src/lib/managers/v2/accountsManager.ts
+++ b/src/lib/managers/v2/accountsManager.ts
@@ -1,0 +1,7 @@
+import { ManagerMixin } from '../../mixins';
+import { Account } from '../../resources/v2/account';
+
+export class AccountsManager extends ManagerMixin<Account> {
+  static resource = 'account';
+  static methods = ['all', 'get', 'create'];
+}

--- a/src/lib/managers/v2/index.ts
+++ b/src/lib/managers/v2/index.ts
@@ -1,0 +1,4 @@
+export * from './transfersManager';
+export * from './accountsManager';
+export * from './accountNumbersManager';
+export * from './simulateManager';

--- a/src/lib/managers/v2/simulateManager.ts
+++ b/src/lib/managers/v2/simulateManager.ts
@@ -1,0 +1,14 @@
+import { ResourceArguments } from '../../../types';
+import { ManagerMixin } from '../../mixins';
+import { Transfer } from '../../resources/v2';
+
+export class SimulateManager extends ManagerMixin<Transfer> {
+  static resource = 'transfer';
+  static methods = ['receiveTransfer'];
+
+  receiveTransfer(args?: ResourceArguments) {
+    const innerArgs = args || {};
+    const path = `${this.buildPath()}/receive_transfer`;
+    return this._create({ path_: path, ...innerArgs });
+  }
+}

--- a/src/lib/managers/v2/transfersManager.ts
+++ b/src/lib/managers/v2/transfersManager.ts
@@ -1,0 +1,7 @@
+import { ManagerMixin } from '../../mixins';
+import { Transfer } from '../../resources/v2/transfer';
+
+export class TransfersManager extends ManagerMixin<Transfer> {
+  static resource = 'transfer';
+  static methods = ['all', 'get', 'create'];
+}

--- a/src/lib/mixins/managerMixin.ts
+++ b/src/lib/mixins/managerMixin.ts
@@ -104,7 +104,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   }
 
   @canRaiseHTTPError
-  private async _all(
+  protected async _all(
     args?: ResourceArguments,
   ): Promise<ResourceType[] | AsyncGenerator<ResourceType>> {
     const innerArgs = args || {};
@@ -121,7 +121,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   }
 
   @canRaiseHTTPError
-  private async _get(identifier: string, args?: ResourceArguments): Promise<ResourceType> {
+  protected async _get(identifier: string, args?: ResourceArguments): Promise<ResourceType> {
     const innerArgs = args || {};
     const klass = await getResourceClass(this.#originatingClass.resource);
     const object = await resourceGet<ResourceType>(
@@ -137,12 +137,13 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   }
 
   @canRaiseHTTPError
-  private async _create(args?: ResourceArguments): Promise<ResourceType> {
+  protected async _create(args?: ResourceArguments): Promise<ResourceType> {
     const innerArgs = args || {};
+    const { path_ = this.buildPath() } = innerArgs;
     const klass = await getResourceClass(this.#originatingClass.resource);
     const object = await resourceCreate<ResourceType>(
       this._client,
-      this.buildPath(innerArgs),
+      path_.toString(),
       klass,
       this.#handlers,
       this.#originatingClass.methods,
@@ -152,7 +153,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   }
 
   @canRaiseHTTPError
-  private async _update(identifier: string, args?: ResourceArguments): Promise<ResourceType> {
+  protected async _update(identifier: string, args?: ResourceArguments): Promise<ResourceType> {
     const innerArgs = args || {};
     const klass = await getResourceClass(this.#originatingClass.resource);
     const object = await resourceUpdate<ResourceType>(
@@ -168,7 +169,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   }
 
   @canRaiseHTTPError
-  private async _delete(identifier: string, args?: ResourceArguments): Promise<string> {
+  protected async _delete(identifier: string, args?: ResourceArguments): Promise<string> {
     const innerArgs = args || {};
     await resourceDelete(
       this._client,

--- a/src/lib/resources/account.ts
+++ b/src/lib/resources/account.ts
@@ -25,7 +25,7 @@ export class Account extends ResourceMixin<Account> {
     console.warn('Warning: Account.movements is deprecated and will be removed in a future version. Please use the Fintoc client directly to access movements. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#movementsManager === undefined) {
       this.#movementsManager = new MovementsManager(
-        `/accounts/${this.id}/movements`, this._client,
+        `/v1/accounts/${this.id}/movements`, this._client,
       );
     }
     return this.#movementsManager;

--- a/src/lib/resources/link.ts
+++ b/src/lib/resources/link.ts
@@ -48,7 +48,7 @@ export class Link extends ResourceMixin<Link> {
     console.warn('Warning: Link.accounts is deprecated and will be removed in a future version. Please use the Fintoc client directly to access accounts. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#accountsManager === undefined) {
       this.#accountsManager = new AccountsManager(
-        '/accounts', this._useClient(),
+        '/v1/accounts', this._useClient(),
       );
     }
     return this.#accountsManager;
@@ -66,7 +66,7 @@ export class Link extends ResourceMixin<Link> {
     console.warn('Warning: Link.subscriptions is deprecated and will be removed in a future version. Please use the Fintoc client directly to access subscriptions. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#subscriptionsManager === undefined) {
       this.#subscriptionsManager = new SubscriptionsManager(
-        '/subscriptions', this._useClient(),
+        '/v1/subscriptions', this._useClient(),
       );
     }
     return this.#subscriptionsManager;
@@ -84,7 +84,7 @@ export class Link extends ResourceMixin<Link> {
     console.warn('Warning: Link.taxReturns is deprecated and will be removed in a future version. Please use the Fintoc client directly to access taxReturns. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#taxReturnsManager === undefined) {
       this.#taxReturnsManager = new TaxReturnsManager(
-        '/tax_returns', this._useClient(),
+        '/v1/tax_returns', this._useClient(),
       );
     }
     return this.#taxReturnsManager;
@@ -102,7 +102,7 @@ export class Link extends ResourceMixin<Link> {
     console.warn('Warning: Link.invoices is deprecated and will be removed in a future version. Please use the Fintoc client directly to access invoices. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#invoicesManager === undefined) {
       this.#invoicesManager = new InvoicesManager(
-        '/invoices', this._useClient(),
+        '/v1/invoices', this._useClient(),
       );
     }
     return this.#invoicesManager;
@@ -120,7 +120,7 @@ export class Link extends ResourceMixin<Link> {
     console.warn('Warning: Link.refreshIntents is deprecated and will be removed in a future version. Please use the Fintoc client directly to access refreshIntents. See: https://github.com/fintoc-com/fintoc-node/pull/34');
     if (this.#refreshIntentsManager === undefined) {
       this.#refreshIntentsManager = new RefreshIntentsManager(
-        '/refresh_intents', this._useClient(),
+        '/v1/refresh_intents', this._useClient(),
       );
     }
     return this.#refreshIntentsManager;

--- a/src/lib/resources/v2/account.ts
+++ b/src/lib/resources/v2/account.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class Account extends ResourceMixin<Account> {
+}

--- a/src/lib/resources/v2/accountNumber.ts
+++ b/src/lib/resources/v2/accountNumber.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class AccountNumber extends ResourceMixin<AccountNumber> {
+}

--- a/src/lib/resources/v2/index.ts
+++ b/src/lib/resources/v2/index.ts
@@ -1,0 +1,3 @@
+export * from './transfer';
+export * from './account';
+export * from './accountNumber';

--- a/src/lib/resources/v2/transfer.ts
+++ b/src/lib/resources/v2/transfer.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class Transfer extends ResourceMixin<Transfer> {
+}

--- a/src/spec/client/creationFunctionality.spec.ts
+++ b/src/spec/client/creationFunctionality.spec.ts
@@ -49,7 +49,7 @@ test('"Client" headers', (t) => {
   const ctx: any = t.context;
   const client = ctx.createClient();
   t.assert(client instanceof Client);
-  t.assert(Object.keys(client.headers).length === 2);
+  t.assert(Object.keys(client.headers).length === 3);
   t.assert('Authorization' in client.headers);
   t.assert('User-Agent' in client.headers);
   t.assert(client.headers.Authorization === ctx.apiKey);

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -391,3 +391,145 @@ test('account.movements.get()', async (t) => {
   t.is(movement.url, `v1/accounts/${accountId}/movements/${movementId}`);
   t.is(movement._client.params.link_token, linkToken);
 });
+
+test('fintoc.v2.transfers.all()', async (t) => {
+  const ctx: any = t.context;
+  const transfers = await ctx.fintoc.v2.transfers.all();
+
+  let count = 0;
+  for await (const transfer of transfers) {
+    count += 1;
+    t.is(transfer.method, 'get');
+    t.is(transfer.url, 'v2/transfers');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.v2.transfers.get()', async (t) => {
+  const ctx: any = t.context;
+  const transferId = 'transfer_id';
+  const transfer = await ctx.fintoc.v2.transfers.get(transferId);
+
+  t.is(transfer.method, 'get');
+  t.is(transfer.url, `v2/transfers/${transferId}`);
+});
+
+test('fintoc.v2.transfers.create()', async (t) => {
+  const ctx: any = t.context;
+  const transferData = {
+    amount: 10000,
+    currency: 'MXN',
+    counterparty: {
+      account_number: '012969100000000026',
+    },
+  };
+  const transfer = await ctx.fintoc.v2.transfers.create(transferData);
+
+  t.is(transfer.method, 'post');
+  t.is(transfer.url, 'v2/transfers');
+  t.is(transfer.json.amount, transferData.amount);
+  t.is(transfer.json.currency, transferData.currency);
+  t.is(transfer.json.counterparty.account_number, transferData.counterparty.account_number);
+});
+
+test('fintoc.v2.accounts.all()', async (t) => {
+  const ctx: any = t.context;
+  const accounts = await ctx.fintoc.v2.accounts.all();
+
+  let count = 0;
+  for await (const account of accounts) {
+    count += 1;
+    t.is(account.method, 'get');
+    t.is(account.url, 'v2/accounts');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.v2.accounts.get()', async (t) => {
+  const ctx: any = t.context;
+  const accountId = 'account_id';
+  const account = await ctx.fintoc.v2.accounts.get(accountId);
+
+  t.is(account.method, 'get');
+  t.is(account.url, `v2/accounts/${accountId}`);
+});
+
+test('fintoc.v2.accounts.create()', async (t) => {
+  const ctx: any = t.context;
+  const accountData = {
+    description: 'Test Account',
+  };
+  const account = await ctx.fintoc.v2.accounts.create(accountData);
+
+  t.is(account.method, 'post');
+  t.is(account.url, 'v2/accounts');
+  t.is(account.json.description, accountData.description);
+});
+
+test('fintoc.v2.accountNumbers.all()', async (t) => {
+  const ctx: any = t.context;
+  const accountNumbers = await ctx.fintoc.v2.accountNumbers.all();
+
+  let count = 0;
+  for await (const accountNumber of accountNumbers) {
+    count += 1;
+    t.is(accountNumber.method, 'get');
+    t.is(accountNumber.url, 'v2/account_numbers');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.v2.accountNumbers.get()', async (t) => {
+  const ctx: any = t.context;
+  const accountNumberId = 'account_number_id';
+  const accountNumber = await ctx.fintoc.v2.accountNumbers.get(accountNumberId);
+
+  t.is(accountNumber.method, 'get');
+  t.is(accountNumber.url, `v2/account_numbers/${accountNumberId}`);
+});
+
+test('fintoc.v2.accountNumbers.create()', async (t) => {
+  const ctx: any = t.context;
+  const accountNumberData = {
+    account_id: 'account_123',
+    description: 'test acc number',
+  };
+  const accountNumber = await ctx.fintoc.v2.accountNumbers.create(accountNumberData);
+
+  t.is(accountNumber.method, 'post');
+  t.is(accountNumber.url, 'v2/account_numbers');
+  t.is(accountNumber.json.account_id, accountNumberData.account_id);
+  t.is(accountNumber.json.description, accountNumberData.description);
+});
+
+test('fintoc.v2.accountNumbers.update()', async (t) => {
+  const ctx: any = t.context;
+  const accountNumberId = 'account_number_id';
+  const updateData = {
+    status: 'enabled',
+  };
+  const accountNumber = await ctx.fintoc.v2.accountNumbers.update(accountNumberId, updateData);
+
+  t.is(accountNumber.method, 'patch');
+  t.is(accountNumber.url, `v2/account_numbers/${accountNumberId}`);
+  t.is(accountNumber.json.status, updateData.status);
+});
+
+test('fintoc.v2.simulate.receiveTransfer()', async (t) => {
+  const ctx: any = t.context;
+  const transferData = {
+    amount: 50000,
+    currency: 'MXN',
+    account_number_id: 'account_number_123',
+  };
+  const result = await ctx.fintoc.v2.simulate.receiveTransfer(transferData);
+
+  t.is(result.method, 'post');
+  t.is(result.url, 'v2/simulate/receive_transfer');
+  t.is(result.json.amount, transferData.amount);
+  t.is(result.json.currency, transferData.currency);
+  t.is(result.json.account_number_id, transferData.account_number_id);
+});

--- a/src/spec/jws.spec.ts
+++ b/src/spec/jws.spec.ts
@@ -1,0 +1,183 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import test from 'ava';
+
+import { JWSSignature } from '../lib/jws';
+
+function generateTestKeyPair() {
+  return crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+}
+
+function createTempKeyFile(privateKey: string): string {
+  const tempDir = os.tmpdir();
+  const tempFile = path.join(tempDir, `test-key-${Date.now()}.pem`);
+  fs.writeFileSync(tempFile, privateKey);
+  return tempFile;
+}
+
+function parseJWSHeader(jwsHeader: string) {
+  const [protectedHeaderBase64] = jwsHeader.split('.');
+  const protectedHeader = JSON.parse(Buffer.from(protectedHeaderBase64, 'base64url').toString());
+  return protectedHeader;
+}
+
+function verifyJWSSignature(jwsHeader: string, payload: string, publicKey: string): boolean {
+  const [protectedHeaderBase64, signatureBase64] = jwsHeader.split('.');
+  const payloadBase64 = Buffer.from(payload).toString('base64url');
+  const signingInput = `${protectedHeaderBase64}.${payloadBase64}`;
+
+  const signature = Buffer.from(signatureBase64, 'base64url');
+
+  const verifier = crypto.createVerify('sha256');
+  verifier.update(signingInput);
+  return verifier.verify(publicKey, signature);
+}
+
+test.beforeEach((t) => {
+  const ctx: any = t.context;
+  const keyPair = generateTestKeyPair();
+  ctx.privateKey = keyPair.privateKey;
+  ctx.publicKey = keyPair.publicKey;
+  ctx.testPayload = '{"test": "data"}';
+});
+
+test.afterEach((t) => {
+  const ctx: any = t.context;
+  if (ctx.tempKeyFile && fs.existsSync(ctx.tempKeyFile)) {
+    fs.unlinkSync(ctx.tempKeyFile);
+  }
+});
+
+test('JWSSignature initialization with PEM string', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  t.truthy(jws);
+});
+
+test('JWSSignature initialization with PEM buffer', (t) => {
+  const ctx: any = t.context;
+  const keyBuffer = Buffer.from(ctx.privateKey, 'utf8');
+  const jws = new JWSSignature(keyBuffer);
+  t.truthy(jws);
+});
+
+test('JWSSignature initialization with file path', (t) => {
+  const ctx: any = t.context;
+  const tempKeyFile = createTempKeyFile(ctx.privateKey);
+  ctx.tempKeyFile = tempKeyFile;
+
+  const jws = new JWSSignature(tempKeyFile);
+  t.truthy(jws);
+});
+
+test('JWSSignature throws error with invalid input type', (t) => {
+  t.throws(() => {
+    // eslint-disable-next-line no-new
+    new JWSSignature(123 as any);
+  }, { message: /Private key must be a string/ });
+});
+
+test('JWSSignature throws error with non-existent file path', (t) => {
+  t.throws(() => {
+    // eslint-disable-next-line no-new
+    new JWSSignature('/non/existent/path.pem');
+  }, { message: /Failed to read private key file/ });
+});
+
+test('JWSSignature throws error with invalid key format', (t) => {
+  t.throws(() => {
+    // eslint-disable-next-line no-new
+    new JWSSignature('invalid-key-content');
+  }, { message: /Invalid private key format/ });
+});
+
+test('generateHeader creates valid JWS header structure', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader(ctx.testPayload);
+
+  t.is(header.split('.').length, 2);
+
+  const protectedHeader = parseJWSHeader(header);
+  t.is(protectedHeader.alg, 'RS256');
+  t.truthy(protectedHeader.nonce);
+  t.truthy(protectedHeader.ts);
+  t.deepEqual(protectedHeader.crit, ['ts', 'nonce']);
+});
+
+test('generateHeader creates valid cryptographic signature', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader(ctx.testPayload);
+
+  const isValid = verifyJWSSignature(header, ctx.testPayload, ctx.publicKey);
+  t.true(isValid);
+});
+
+test('generateHeader timestamp is current', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader(ctx.testPayload);
+
+  const protectedHeader = parseJWSHeader(header);
+  const headerTimestamp = protectedHeader.ts;
+  const currentTimestamp = Math.floor(Date.now() / 1000);
+
+  t.true(Math.abs(currentTimestamp - headerTimestamp) <= 10);
+});
+
+test('generateHeader creates unique nonces', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+
+  const header1 = jws.generateHeader(ctx.testPayload);
+  const header2 = jws.generateHeader(ctx.testPayload);
+
+  const protectedHeader1 = parseJWSHeader(header1);
+  const protectedHeader2 = parseJWSHeader(header2);
+
+  t.not(protectedHeader1.nonce, protectedHeader2.nonce);
+});
+
+test('generateHeader works with empty payload', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader('');
+
+  const isValid = verifyJWSSignature(header, '', ctx.publicKey);
+  t.true(isValid);
+});
+
+test('generateHeader works with complex JSON payload', (t) => {
+  const ctx: any = t.context;
+  const complexPayload = JSON.stringify({
+    user: 'test@example.com',
+    data: { nested: { value: 123 }, array: [1, 2, 3] },
+    timestamp: Date.now(),
+  });
+
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader(complexPayload);
+
+  const isValid = verifyJWSSignature(header, complexPayload, ctx.publicKey);
+  t.true(isValid);
+});
+
+test('nonce is hexadecimal string of correct length', (t) => {
+  const ctx: any = t.context;
+  const jws = new JWSSignature(ctx.privateKey);
+  const header = jws.generateHeader(ctx.testPayload);
+
+  const protectedHeader = parseJWSHeader(header);
+  const { nonce } = protectedHeader;
+
+  t.is(nonce.length, 32);
+  t.regex(nonce, /^[0-9a-f]+$/);
+});

--- a/src/spec/mocks/client/axiosInstance.ts
+++ b/src/spec/mocks/client/axiosInstance.ts
@@ -35,7 +35,7 @@ export class MockAxiosInstance extends Axios {
       baseURL: usingBaseURL,
       url: usableURL,
       params: completeParams,
-      json: data,
+      json: JSON.parse(data || '{}'),
     });
   }
 }


### PR DESCRIPTION
## Description

This PR adds support for v2/transfers product. It includes generating the JWS and all the endpoints for transfers.

```javascript
import { Fintoc } from 'fintoc';

// Provide a path to the PEM file
const fintoc = new Fintoc('my_api_key', 'private_key.pem');

// Or pass the PEM directly as a string
const fintoc = new Fintoc('my_api_key', process.env.JWS_PRIVATE_KEY);

const transfer = await fintoc.v2.transfers.create({
    amount: 49124,
    currency: 'mxn',
    account_id: 'account_id',
    comment: 'Dispersion 12314',
    reference_id: '16584',
    counterparty: {
      account_number: '012969100000000026',
    },
    metadata: {
      customer_id: '19385014'
    }
  });
const inboundTransfer = await fintoc.v2.simulate.receiveTransfer({
  account_number_id: 'account_id',
  amount: 58145,
  currency: 'mxn'
})
```

## Requirements

None.

## Additional changes

None.
