### PR TITLE
Feat/add idempotency key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
     - [update](#update)
     - [delete](#delete)
   - [Webhook Signature Validation](#webhook-signature-validation)
+  - [Idempotency Keys](#idempotency-keys)
   - [Serialization](#serialization)
 - [Acknowledgements](#acknowledgements)
 
@@ -186,6 +187,25 @@ If the signature is invalid or the timestamp is outside the tolerance window, a 
 
 
 For a complete example of handling webhooks, see [examples/webhook.js](examples/webhook.js).
+
+### Idempotency Keys
+
+You can provide an [Idempotency Key](https://docs.fintoc.com/reference/idempotent-requests) using the `idempotency_key` argument. For example:
+
+```javascript
+const transfer = await fintoc.v2.transfers.create({
+    idempotency_key: '12345678',
+    amount: 54123,
+    currency: 'mxn',
+    account_id: 'acc_12345678',
+    counterparty: {
+      account_number: '012969100000000026',
+    },
+    metadata: {
+      customer_id: '19385014'
+    }
+  });
+```
 
 ### Serialization
 

--- a/src/interfaces/client/requestOptions.ts
+++ b/src/interfaces/client/requestOptions.ts
@@ -6,4 +6,5 @@ export interface IRequestOptions {
   method?: Method,
   params?: Record<string, any>,
   json?: Record<string, string>,
+  idempotencyKey?: string,
 }

--- a/src/lib/mixins/managerMixin.ts
+++ b/src/lib/mixins/managerMixin.ts
@@ -139,7 +139,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
   @canRaiseHTTPError
   protected async _create(args?: ResourceArguments): Promise<ResourceType> {
     const innerArgs = args || {};
-    const { path_ = this.buildPath() } = innerArgs;
+    const { path_ = this.buildPath(), idempotency_key: idempotencyKey } = innerArgs;
     const klass = await getResourceClass(this.#originatingClass.resource);
     const object = await resourceCreate<ResourceType>(
       this._client,
@@ -148,6 +148,7 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
       this.#handlers,
       this.#originatingClass.methods,
       innerArgs,
+      idempotencyKey?.toString(),
     );
     return this.postCreateHandler(object, innerArgs);
   }

--- a/src/lib/resourceHandlers.ts
+++ b/src/lib/resourceHandlers.ts
@@ -98,8 +98,11 @@ export async function resourceCreate<ResourceType>(
   handlers: Record<string, GenericFunction> = {},
   methods: string[],
   params: Record<string, any>,
+  idempotencyKey?: string,
 ): Promise<ResourceType> {
-  const data = await client.request({ path, method: 'post', json: params });
+  const data = await client.request({
+    path, method: 'post', json: params, idempotencyKey,
+  });
   return objetize(
     klass,
     client,

--- a/src/spec/client/creationFunctionality.spec.ts
+++ b/src/spec/client/creationFunctionality.spec.ts
@@ -49,11 +49,11 @@ test('"Client" headers', (t) => {
   const ctx: any = t.context;
   const client = ctx.createClient();
   t.assert(client instanceof Client);
-  t.assert(Object.keys(client.headers).length === 3);
-  t.assert('Authorization' in client.headers);
-  t.assert('User-Agent' in client.headers);
-  t.assert(client.headers.Authorization === ctx.apiKey);
-  t.assert(client.headers['User-Agent'] === ctx.userAgent);
+  t.assert(Object.keys(client.staticHeaders).length === 3);
+  t.assert('Authorization' in client.staticHeaders);
+  t.assert('User-Agent' in client.staticHeaders);
+  t.assert(client.staticHeaders.Authorization === ctx.apiKey);
+  t.assert(client.staticHeaders['User-Agent'] === ctx.userAgent);
 });
 
 test('"Client" extension', (t) => {

--- a/src/spec/client/requestFunctionality.spec.ts
+++ b/src/spec/client/requestFunctionality.spec.ts
@@ -50,3 +50,34 @@ test('"Client" delete request', async (t) => {
   t.assert(isDictLike(data));
   t.assert(Object.keys(data).length === 0);
 });
+
+test('"Client" post request without idempotency key adds one automatically', async (t) => {
+  const ctx: any = t.context;
+
+  const data = await ctx.client.request({
+    path: '/movements',
+    method: 'post',
+    json: { test: 'data' },
+  });
+
+  t.assert(!isAsyncGenerator(data));
+  t.assert(isDictLike(data));
+  t.assert(typeof data.headers['Idempotency-Key'] === 'string');
+  t.assert(data.headers['Idempotency-Key'].length > 0);
+});
+
+test('"Client" post request with idempotency key uses provided key', async (t) => {
+  const ctx: any = t.context;
+  const testIdempotencyKey = 'test-idempotency-key-123';
+
+  const data = await ctx.client.request({
+    path: '/movements',
+    method: 'post',
+    json: { test: 'data' },
+    idempotencyKey: testIdempotencyKey,
+  });
+
+  t.assert(!isAsyncGenerator(data));
+  t.assert(isDictLike(data));
+  t.assert(data.headers['Idempotency-Key'] === testIdempotencyKey);
+});

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -431,6 +431,24 @@ test('fintoc.v2.transfers.create()', async (t) => {
   t.is(transfer.json.amount, transferData.amount);
   t.is(transfer.json.currency, transferData.currency);
   t.is(transfer.json.counterparty.account_number, transferData.counterparty.account_number);
+  t.true(transfer.headers['Idempotency-Key'] && transfer.headers['Idempotency-Key'].length > 0);
+});
+
+test('fintoc.v2.transfers.create() with idempotency key', async (t) => {
+  const ctx: any = t.context;
+  const transferData = {
+    amount: 10000,
+    currency: 'MXN',
+    idempotency_key: 'idempotency_key_123',
+    counterparty: {
+      account_number: '012969100000000026',
+    },
+  };
+  const transfer = await ctx.fintoc.v2.transfers.create(transferData);
+
+  t.is(transfer.method, 'post');
+  t.is(transfer.url, 'v2/transfers');
+  t.is(transfer.headers['Idempotency-Key'], transferData.idempotency_key);
 });
 
 test('fintoc.v2.accounts.all()', async (t) => {

--- a/src/spec/mocks/client/axiosInstance.ts
+++ b/src/spec/mocks/client/axiosInstance.ts
@@ -22,7 +22,7 @@ export class MockAxiosInstance extends Axios {
   // @ts-ignore: return type is not assignable
   async request(config: AxiosRequestConfig) {
     const {
-      method, url, params, data,
+      method, url, params, data, headers,
     } = config;
     const usingMethod = method || 'get';
     const usingBaseURL = this.baseURL || '';
@@ -36,6 +36,7 @@ export class MockAxiosInstance extends Axios {
       url: usableURL,
       params: completeParams,
       json: JSON.parse(data || '{}'),
+      headers: headers || {},
     });
   }
 }

--- a/src/spec/mocks/client/response.ts
+++ b/src/spec/mocks/client/response.ts
@@ -5,14 +5,16 @@ export class MockResponse {
   method: string;
   url: string;
   json: Record<string, any> | undefined;
+  requestHeaders: Record<string, any>;
 
   constructor(config: Record<string, any>) {
     const {
-      method, baseURL, url, params, json,
+      method, baseURL, url, params, json, headers,
     } = config;
 
     this.baseURL = baseURL;
     this.params = params;
+    this.requestHeaders = headers || {};
 
     let page;
     if (method === 'get' && url.charAt(url.length - 1) === 's') {
@@ -51,6 +53,7 @@ export class MockResponse {
       url: this.url,
       params: this.params,
       json: this.json,
+      headers: this.requestHeaders,
     };
   }
 


### PR DESCRIPTION
## Description

Add the option to add idempotency keys to POST requests:

```javascript
const transfer = await fintoc.v2.transfers.create({
    idempotency_key: '12345678',
    amount: 54123,
    currency: 'mxn',
    account_id: 'acc_12345678',
    counterparty: {
      account_number: '012969100000000026',
    },
    metadata: {
      customer_id: '19385014'
    }
  });
```

When no idempotency key is passed by the user, the SDK automatically provides one. We will use this feature to do automatic retries in a future PR 👀

## Requirements

None.

## Additional changes

None.
