### PR TITLE
Refactor/list instead of all

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 - [Usage](#usage)
   - [Quickstart](#quickstart)
   - [Calling endpoints](#calling-endpoints)
-    - [all](#all)
+    - [list](#list)
     - [get](#get)
     - [create](#create)
     - [update](#update)
@@ -63,7 +63,7 @@ import { Fintoc } from 'fintoc';
 const fintocClient = new Fintoc('your_api_key');
 
 // List all succeeded payment intents since the beginning of 2025
-const paymentIntents = await fintocClient.paymentIntents.all({ since: '2025-01-01' });
+const paymentIntents = await fintocClient.paymentIntents.list({ since: '2025-01-01' });
 for await (const pi of paymentIntents) {
   console.log(pi.created_at, pi.amount, pi.status);
 }
@@ -79,18 +79,18 @@ The SDK provides direct access to Fintoc API resources following the API structu
 
 Notice that **not every resource has all of the methods**, as they correspond to the API capabilities.
 
-#### `all`
+#### `list`
 
-You can use the `all` method to list all the instances of the resource:
+You can use the `list` method to list all the instances of the resource:
 
 ```javascript
-const webhookEndpoints = await fintocClient.webhookEndpoints.all();
+const webhookEndpoints = await fintocClient.webhookEndpoints.list();
 ```
 
-The `all` method returns an **async generator** with all the instances of the resource. This method can also receive the arguments that the API receives for that specific resource. For example, the `PaymentIntent` resource can be filtered using `since` and `until`, so if you wanted to get a range of `payment intents`, all you need to do is to pass the parameters to the method:
+The `list` method returns an **async generator** with all the instances of the resource. This method can also receive the arguments that the API receives for that specific resource. For example, the `PaymentIntent` resource can be filtered using `since` and `until`, so if you wanted to get a range of `payment intents`, all you need to do is to pass the parameters to the method:
 
 ```javascript
-const paymentIntents = await fintocClient.paymentIntents.all({
+const paymentIntents = await fintocClient.paymentIntents.list({
   since: '2019-07-24',
   until: '2021-05-12',
 });
@@ -99,7 +99,7 @@ const paymentIntents = await fintocClient.paymentIntents.all({
 Notice that, in order to iterate over the async generator, you need to `await` the generator itself **and then** each of the instances:
 
 ```javascript
-const paymentIntents = await fintocClient.paymentIntents.all({
+const paymentIntents = await fintocClient.paymentIntents.list({
   since: '2019-07-24',
   until: '2021-05-12',
 });
@@ -112,7 +112,7 @@ for await (const paymentIntent of paymentIntents) {
 You can also pass the `lazy: false` parameter to the method to force the SDK to return a list of all the instances of the resource instead of the generator. **Beware**: this could take **very long**, depending on the amount of instances that exist of said resource:
 
 ```javascript
-const paymentIntents = await fintocClient.paymentIntents.all({ lazy: false });
+const paymentIntents = await fintocClient.paymentIntents.list({ lazy: false });
 
 Array.isArray(paymentIntents); // true
 ```
@@ -212,7 +212,7 @@ const transfer = await fintoc.v2.transfers.create({
 Any resource of the SDK can be serialized! To get the serialized resource, just call the `serialize` method!
 
 ```javascript
-const account = (await link.accounts.all({ lazy: false }))[0];
+const account = (await link.accounts.list({ lazy: false }))[0];
 
 const serialization = account.serialize();
 ```

--- a/src/lib/managers/accountsManager.ts
+++ b/src/lib/managers/accountsManager.ts
@@ -6,7 +6,7 @@ import { MovementsManager } from './movementsManager';
 
 export class AccountsManager extends ManagerMixin<Account> {
   static resource = 'account';
-  static methods = ['all', 'get'];
+  static methods = ['list', 'get'];
 
   movements: MovementsManager;
 

--- a/src/lib/managers/invoicesManager.ts
+++ b/src/lib/managers/invoicesManager.ts
@@ -3,5 +3,5 @@ import { Invoice } from '../resources/invoice';
 
 export class InvoicesManager extends ManagerMixin<Invoice> {
   static resource = 'invoice';
-  static methods = ['all'];
+  static methods = ['list'];
 }

--- a/src/lib/managers/linksManager.ts
+++ b/src/lib/managers/linksManager.ts
@@ -5,7 +5,7 @@ import { Link } from '../resources/link';
 
 export class LinksManager extends ManagerMixin<Link> {
   static resource = 'link';
-  static methods = ['all', 'get', 'update', 'delete'];
+  static methods = ['list', 'get', 'update', 'delete'];
 
   protected postGetHandler(
     object: Link, identifier: string, args: ResourceArguments,

--- a/src/lib/managers/movementsManager.ts
+++ b/src/lib/managers/movementsManager.ts
@@ -3,5 +3,5 @@ import { Movement } from '../resources/movement';
 
 export class MovementsManager extends ManagerMixin<Movement> {
   static resource = 'movement';
-  static methods = ['all', 'get'];
+  static methods = ['list', 'get'];
 }

--- a/src/lib/managers/paymentIntentsManager.ts
+++ b/src/lib/managers/paymentIntentsManager.ts
@@ -3,5 +3,5 @@ import { PaymentIntent } from '../resources/paymentIntent';
 
 export class PaymentIntentsManager extends ManagerMixin<PaymentIntent> {
   static resource = 'payment_intent';
-  static methods = ['all', 'get', 'create'];
+  static methods = ['list', 'get', 'create'];
 }

--- a/src/lib/managers/refreshIntentsManager.ts
+++ b/src/lib/managers/refreshIntentsManager.ts
@@ -3,5 +3,5 @@ import { RefreshIntent } from '../resources/refreshIntent';
 
 export class RefreshIntentsManager extends ManagerMixin<RefreshIntent> {
   static resource = 'refresh_intent';
-  static methods = ['all', 'get', 'create'];
+  static methods = ['list', 'get', 'create'];
 }

--- a/src/lib/managers/subscriptionsManager.ts
+++ b/src/lib/managers/subscriptionsManager.ts
@@ -3,5 +3,5 @@ import { Subscription } from '../resources/subscription';
 
 export class SubscriptionsManager extends ManagerMixin<Subscription> {
   static resource = 'subscription';
-  static methods = ['all', 'get'];
+  static methods = ['list', 'get'];
 }

--- a/src/lib/managers/taxReturnsManager.ts
+++ b/src/lib/managers/taxReturnsManager.ts
@@ -3,5 +3,5 @@ import { TaxReturn } from '../resources/taxReturn';
 
 export class TaxReturnsManager extends ManagerMixin<TaxReturn> {
   static resource = 'tax_return';
-  static methods = ['all', 'get'];
+  static methods = ['list', 'get'];
 }

--- a/src/lib/managers/v2/accountNumbersManager.ts
+++ b/src/lib/managers/v2/accountNumbersManager.ts
@@ -3,5 +3,5 @@ import { AccountNumber } from '../../resources/v2/accountNumber';
 
 export class AccountNumbersManager extends ManagerMixin<AccountNumber> {
   static resource = 'account_number';
-  static methods = ['all', 'get', 'create', 'update'];
+  static methods = ['list', 'get', 'create', 'update'];
 }

--- a/src/lib/managers/v2/accountsManager.ts
+++ b/src/lib/managers/v2/accountsManager.ts
@@ -3,5 +3,5 @@ import { Account } from '../../resources/v2/account';
 
 export class AccountsManager extends ManagerMixin<Account> {
   static resource = 'account';
-  static methods = ['all', 'get', 'create'];
+  static methods = ['list', 'get', 'create'];
 }

--- a/src/lib/managers/v2/transfersManager.ts
+++ b/src/lib/managers/v2/transfersManager.ts
@@ -3,5 +3,5 @@ import { Transfer } from '../../resources/v2/transfer';
 
 export class TransfersManager extends ManagerMixin<Transfer> {
   static resource = 'transfer';
-  static methods = ['all', 'get', 'create'];
+  static methods = ['list', 'get', 'create'];
 }

--- a/src/lib/managers/webhookEndpointsManager.ts
+++ b/src/lib/managers/webhookEndpointsManager.ts
@@ -3,5 +3,5 @@ import { WebhookEndpoint } from '../resources/webhookEndpoint';
 
 export class WebhookEndpointsManager extends ManagerMixin<WebhookEndpoint> {
   static resource = 'webhook_endpoint';
-  static methods = ['all', 'get', 'create', 'update', 'delete'];
+  static methods = ['list', 'get', 'create', 'update', 'delete'];
 }

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -20,7 +20,21 @@ test.beforeEach((t) => {
   ctx.fintoc = new Fintoc(apiKey);
 });
 
-test('fintoc.paymentIntents.all()', async (t) => {
+test('fintoc.paymentIntents.list()', async (t) => {
+  const ctx: any = t.context;
+  const paymentIntents = await ctx.fintoc.paymentIntents.list();
+
+  let count = 0;
+  for await (const paymentIntent of paymentIntents) {
+    count += 1;
+    t.is(paymentIntent.method, 'get');
+    t.is(paymentIntent.url, 'v1/payment_intents');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.paymentIntents.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const paymentIntents = await ctx.fintoc.paymentIntents.all();
 
@@ -59,7 +73,21 @@ test('fintoc.paymentIntents.create()', async (t) => {
   t.is(paymentIntent.json.payment_method, paymentData.payment_method);
 });
 
-test('fintoc.links.all()', async (t) => {
+test('fintoc.links.list()', async (t) => {
+  const ctx: any = t.context;
+  const links = await ctx.fintoc.links.list();
+
+  let count = 0;
+  for await (const link of links) {
+    count += 1;
+    t.is(link.method, 'get');
+    t.is(link.url, 'v1/links');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.links.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const links = await ctx.fintoc.links.all();
 
@@ -103,7 +131,21 @@ test('fintoc.links.delete()', async (t) => {
   t.is(deletedIdentifier, linkId);
 });
 
-test('fintoc.accounts.all()', async (t) => {
+test('fintoc.accounts.list()', async (t) => {
+  const ctx: any = t.context;
+  const accounts = await ctx.fintoc.accounts.list();
+
+  let count = 0;
+  for await (const account of accounts) {
+    count += 1;
+    t.is(account.method, 'get');
+    t.is(account.url, 'v1/accounts');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.accounts.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const accounts = await ctx.fintoc.accounts.all();
 
@@ -126,7 +168,28 @@ test('fintoc.accounts.get()', async (t) => {
   t.is(account.url, `v1/accounts/${accountId}`);
 });
 
-test('fintoc.accounts.movements.all()', async (t) => {
+test('fintoc.accounts.movements.list()', async (t) => {
+  const ctx: any = t.context;
+  const linkToken = 'link_token_example';
+  const accountId = 'account_id';
+  const movements = await ctx.fintoc.accounts.movements.list({
+    account_id: accountId,
+    link_token: linkToken,
+  });
+
+  let count = 0;
+  for await (const movement of movements) {
+    count += 1;
+    t.is(movement.method, 'get');
+    t.is(movement.url, `v1/accounts/${accountId}/movements`);
+    t.is(movement.params.link_token, linkToken);
+    t.is(movement.params.account_id, accountId);
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.accounts.movements.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const linkToken = 'link_token_example';
   const accountId = 'account_id';
@@ -164,7 +227,21 @@ test('fintoc.accounts.movements.get()', async (t) => {
   t.is(movement.params.account_id, accountId);
 });
 
-test('fintoc.webhookEndpoints.all()', async (t) => {
+test('fintoc.webhookEndpoints.list()', async (t) => {
+  const ctx: any = t.context;
+  const webhookEndpoints = await ctx.fintoc.webhookEndpoints.list();
+
+  let count = 0;
+  for await (const webhookEndpoint of webhookEndpoints) {
+    count += 1;
+    t.is(webhookEndpoint.method, 'get');
+    t.is(webhookEndpoint.url, 'v1/webhook_endpoints');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.webhookEndpoints.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const webhookEndpoints = await ctx.fintoc.webhookEndpoints.all();
 
@@ -222,7 +299,21 @@ test('fintoc.webhookEndpoints.delete()', async (t) => {
   t.is(deletedIdentifier, webhookEndpointId);
 });
 
-test('fintoc.invoices.all()', async (t) => {
+test('fintoc.invoices.list()', async (t) => {
+  const ctx: any = t.context;
+  const invoices = await ctx.fintoc.invoices.list();
+
+  let count = 0;
+  for await (const invoice of invoices) {
+    count += 1;
+    t.is(invoice.method, 'get');
+    t.is(invoice.url, 'v1/invoices');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.invoices.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const invoices = await ctx.fintoc.invoices.all();
 
@@ -236,7 +327,21 @@ test('fintoc.invoices.all()', async (t) => {
   t.true(count > 0);
 });
 
-test('fintoc.refreshIntents.all()', async (t) => {
+test('fintoc.refreshIntents.list()', async (t) => {
+  const ctx: any = t.context;
+  const refreshIntents = await ctx.fintoc.refreshIntents.list();
+
+  let count = 0;
+  for await (const refreshIntent of refreshIntents) {
+    count += 1;
+    t.is(refreshIntent.method, 'get');
+    t.is(refreshIntent.url, 'v1/refresh_intents');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.refreshIntents.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const refreshIntents = await ctx.fintoc.refreshIntents.all();
 
@@ -273,7 +378,21 @@ test('fintoc.refreshIntents.create()', async (t) => {
   t.is(refreshIntent.json.refresh_type, refreshData.refresh_type);
 });
 
-test('fintoc.subscriptions.all()', async (t) => {
+test('fintoc.subscriptions.list()', async (t) => {
+  const ctx: any = t.context;
+  const subscriptions = await ctx.fintoc.subscriptions.list();
+
+  let count = 0;
+  for await (const subscription of subscriptions) {
+    count += 1;
+    t.is(subscription.method, 'get');
+    t.is(subscription.url, 'v1/subscriptions');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.subscriptions.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const subscriptions = await ctx.fintoc.subscriptions.all();
 
@@ -296,7 +415,21 @@ test('fintoc.subscriptions.get()', async (t) => {
   t.is(subscription.url, `v1/subscriptions/${subscriptionId}`);
 });
 
-test('fintoc.taxReturns.all()', async (t) => {
+test('fintoc.taxReturns.list()', async (t) => {
+  const ctx: any = t.context;
+  const taxReturns = await ctx.fintoc.taxReturns.list();
+
+  let count = 0;
+  for await (const taxReturn of taxReturns) {
+    count += 1;
+    t.is(taxReturn.method, 'get');
+    t.is(taxReturn.url, 'v1/tax_returns');
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.taxReturns.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const taxReturns = await ctx.fintoc.taxReturns.all();
 
@@ -319,7 +452,26 @@ test('fintoc.taxReturns.get()', async (t) => {
   t.is(taxReturn.url, `v1/tax_returns/${taxReturnId}`);
 });
 
-test('link.accounts.all()', async (t) => {
+test('link.accounts.list()', async (t) => {
+  const ctx: any = t.context;
+  const linkToken = 'link_token_example';
+  const link = await ctx.fintoc.links.get(linkToken);
+
+  const accounts = await link.accounts.list();
+
+  t.is(link.accounts._client.params.link_token, linkToken);
+
+  let count = 0;
+  for await (const account of accounts) {
+    count += 1;
+    t.is(account.method, 'get');
+    t.is(account.url, 'v1/accounts');
+  }
+
+  t.true(count > 0);
+});
+
+test('link.accounts.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const linkToken = 'link_token_example';
   const link = await ctx.fintoc.links.get(linkToken);
@@ -353,7 +505,30 @@ test('link.accounts.get()', async (t) => {
   t.is(account._client.params.link_token, linkToken);
 });
 
-test('account.movements.all()', async (t) => {
+test('account.movements.list()', async (t) => {
+  const ctx: any = t.context;
+  const linkToken = 'link_token_example';
+  const link = await ctx.fintoc.links.get(linkToken);
+
+  const accountId = 'account_id';
+  const account = await link.accounts.get(accountId);
+
+  const movements = await account.movements.list();
+
+  t.is(account.movements._client.params.link_token, linkToken);
+
+  let count = 0;
+  for await (const movement of movements) {
+    count += 1;
+    t.is(movement.method, 'get');
+    t.is(movement.url, `v1/accounts/${accountId}/movements`);
+    t.is(movement._client.params.link_token, linkToken);
+  }
+
+  t.true(count > 0);
+});
+
+test('account.movements.all() - deprecated', async (t) => {
   const ctx: any = t.context;
   const linkToken = 'link_token_example';
   const link = await ctx.fintoc.links.get(linkToken);
@@ -392,9 +567,9 @@ test('account.movements.get()', async (t) => {
   t.is(movement._client.params.link_token, linkToken);
 });
 
-test('fintoc.v2.transfers.all()', async (t) => {
+test('fintoc.v2.transfers.list()', async (t) => {
   const ctx: any = t.context;
-  const transfers = await ctx.fintoc.v2.transfers.all();
+  const transfers = await ctx.fintoc.v2.transfers.list();
 
   let count = 0;
   for await (const transfer of transfers) {
@@ -451,9 +626,9 @@ test('fintoc.v2.transfers.create() with idempotency key', async (t) => {
   t.is(transfer.headers['Idempotency-Key'], transferData.idempotency_key);
 });
 
-test('fintoc.v2.accounts.all()', async (t) => {
+test('fintoc.v2.accounts.list()', async (t) => {
   const ctx: any = t.context;
-  const accounts = await ctx.fintoc.v2.accounts.all();
+  const accounts = await ctx.fintoc.v2.accounts.list();
 
   let count = 0;
   for await (const account of accounts) {
@@ -486,9 +661,9 @@ test('fintoc.v2.accounts.create()', async (t) => {
   t.is(account.json.description, accountData.description);
 });
 
-test('fintoc.v2.accountNumbers.all()', async (t) => {
+test('fintoc.v2.accountNumbers.list()', async (t) => {
   const ctx: any = t.context;
-  const accountNumbers = await ctx.fintoc.v2.accountNumbers.all();
+  const accountNumbers = await ctx.fintoc.v2.accountNumbers.list();
 
   let count = 0;
   for await (const accountNumber of accountNumbers) {

--- a/src/spec/mixins/managerMixin/handlers.spec.ts
+++ b/src/spec/mixins/managerMixin/handlers.spec.ts
@@ -42,7 +42,7 @@ test.serial('"ManagerMixin" handlers all handler', async (t) => {
   await ctx.manager.all();
 
   // @ts-ignore: property does not exist
-  t.assert(console.log.getCall(0).args[0].includes('all'));
+  t.assert(console.log.getCall(0).args[0].includes('list'));
 });
 
 test.serial('"ManagerMixin" handlers get handler', async (t) => {

--- a/src/spec/mixins/managerMixin/mocks/complexMockManager.ts
+++ b/src/spec/mixins/managerMixin/mocks/complexMockManager.ts
@@ -7,13 +7,13 @@ import { GenericMockResource } from './genericMockResource';
 
 export class ComplexMockManager extends ManagerMixin<GenericMockResource> {
   static resource = 'this_resource_does_not_exist';
-  static methods = ['all', 'get', 'create', 'update', 'delete'];
+  static methods = ['list', 'get', 'create', 'update', 'delete'];
 
-  protected postAllHandler(
+  protected postListHandler(
     objects: GenericMockResource[] | AsyncGenerator<GenericMockResource>,
     args: ResourceArguments,
   ) {
-    console.log('Executing the "post all" handler');
+    console.log('Executing the "post list" handler');
     return objects;
   }
 

--- a/src/spec/mixins/managerMixin/mocks/emptyMockManager.ts
+++ b/src/spec/mixins/managerMixin/mocks/emptyMockManager.ts
@@ -4,5 +4,5 @@ import { GenericMockResource } from './genericMockResource';
 
 export class EmptyMockManager extends ManagerMixin<GenericMockResource> {
   static resource = 'this_resource_does_not_exist';
-  static methods = ['all', 'get', 'create', 'update', 'delete'];
+  static methods = ['list', 'get', 'create', 'update', 'delete'];
 }


### PR DESCRIPTION
## Description

Listing resources is now done using `list()` instead of `all()`. This change aligns the SDK better with our API documentation, where we consistently use `list()`.

For backward compatibility, customers can still use `all()`, but they'll receive a warning prompting them to migrate to `list()`.

```javascript
import { Fintoc } from 'fintoc';

const fintocClient = new Fintoc('your_api_key');

// List all payment intents since the beginning of 2025
const paymentIntents = await fintocClient.paymentIntents.list({ since: '2025-01-01' });
```

## Requirements

None.

## Additional changes

None.
