### PR TITLE
[ONB-1914] feat: expose userAgent option in Fintoc constructor

### DIFF
--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -87,10 +87,10 @@ export class Fintoc {
   whoami: WhoamiManager;
   v2: FintocV2;
 
-  constructor(apiKey: string, jwsPrivateKey?: string) {
+  constructor(apiKey: string, jwsPrivateKey?: string, options?: { userAgent?: string }) {
     this.#client = new Client({
       baseUrl: `${API_BASE_URL}`,
-      userAgent: `fintoc-node/${version}`,
+      userAgent: options?.userAgent || `fintoc-node/${version}`,
       apiKey,
       jwsPrivateKey,
     });

--- a/src/spec/core.spec.ts
+++ b/src/spec/core.spec.ts
@@ -9,3 +9,17 @@ test('"Fintoc" object creation', (t) => {
   t.assert(fintoc.links instanceof LinksManager);
   t.assert(fintoc.webhookEndpoints instanceof WebhookEndpointsManager);
 });
+
+test('"Fintoc" object creation with custom userAgent', (t) => {
+  const apiKey = 'super_secret_api_key';
+  const fintoc = new Fintoc(apiKey, undefined, { userAgent: 'fintoc-cli/0.1.0' });
+  t.assert(fintoc.links instanceof LinksManager);
+  t.assert(fintoc.webhookEndpoints instanceof WebhookEndpointsManager);
+  t.is((fintoc.links as any)._client.userAgent, 'fintoc-cli/0.1.0');
+});
+
+test('"Fintoc" object creation uses default userAgent when not provided', (t) => {
+  const apiKey = 'super_secret_api_key';
+  const fintoc = new Fintoc(apiKey);
+  t.true((fintoc.links as any)._client.userAgent.startsWith('fintoc-node/'));
+});


### PR DESCRIPTION
## Contexto

El CLI necesita identificarse como `fintoc-cli/<version>` en los requests, pero `Fintoc` hardcodea el User-Agent a `fintoc-node/<version>`.

## Que hay de nuevo?

- [x] Nuevo parámetro opcional `options?: { userAgent?: string }` en el constructor de `Fintoc`
- [x] Default sigue siendo `fintoc-node/{version}` (no breaking change)

## Tests

- [x] Constructor acepta el nuevo parámetro
- [x] User-Agent custom llega en los headers de los requests
- [x] Sin custom User-Agent usa el default