### PR TITLE
[ONB-1832] Fix string serialization being incorrectly parsed as Date

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,7 +44,8 @@ export function singularize(rawString: string) {
  * @returns A boolean that represents if `rawDate` is parseable as a Date object
  */
 export function isISODate(rawDate: string) {
-  return !Number.isNaN(Date.parse(rawDate));
+  const isoDateRegex = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+  return isoDateRegex.test(rawDate);
 }
 
 /**

--- a/src/spec/utils/getResourceClass.spec.ts
+++ b/src/spec/utils/getResourceClass.spec.ts
@@ -28,6 +28,12 @@ test('"getResourceClass" string resource', async (t) => {
   t.is(klass, String);
 });
 
+test('"getResourceClass" ambiguous string that Date.parse accepts should remain String', async (t) => {
+  const resource = 'any_resource';
+  t.is(await getResourceClass(resource, 'PS 2'), String);
+  t.is(await getResourceClass(resource, 'test 1'), String);
+});
+
 test('"getResourceClass" number resource', async (t) => {
   const resource = 'any_resource';
   const klass = await getResourceClass(resource, 15);

--- a/src/spec/utils/isISODate.spec.ts
+++ b/src/spec/utils/isISODate.spec.ts
@@ -7,7 +7,22 @@ test('"isISODate" valid ISO format', (t) => {
   t.assert(isISODate(validISODaTetimeString));
 });
 
+test('"isISODate" valid ISO date without time', (t) => {
+  t.assert(isISODate('2021-08-13'));
+});
+
+test('"isISODate" valid ISO date with timezone offset', (t) => {
+  t.assert(isISODate('2021-08-13T13:40:40.811+05:00'));
+});
+
 test('"isISODate" invalid ISO format', (t) => {
   const invalidISODaTetimeString = 'This is not a date';
   t.assert(!isISODate(invalidISODaTetimeString));
+});
+
+test('"isISODate" should not parse ambiguous strings as dates', (t) => {
+  t.assert(!isISODate('PS 2'));
+  t.assert(!isISODate('test 1'));
+  t.assert(!isISODate('Mar 5'));
+  t.assert(!isISODate('Jan 2024'));
 });


### PR DESCRIPTION
## Description

`isISODate()` usaba `Date.parse()` para validar si un string es una fecha ISO. El problema es que `Date.parse()` es extremadamente permisivo y parsea strings como `"PS 2"` o `"test 1"` como fechas válidas, causando que nombres de organizaciones y otros textos planos se conviertan en objetos `Date` al construir recursos.

Se reemplazó `Date.parse()` por un regex estricto de ISO 8601 que solo matchea formatos como `2021-08-13` o `2021-08-13T13:40:40.811Z`.

## Requirements

None.

## Additional changes

- [x] Tests unitarios para `isISODate` y `getResourceClass` cubriendo los casos problemáticos

<sup>*Created with Claude Code `/create-pr` command*</sup>