### PR TITLE
Release v1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fintoc",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "The official Node client for the Fintoc API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -87,10 +87,10 @@ export class Fintoc {
   whoami: WhoamiManager;
   v2: FintocV2;
 
-  constructor(apiKey: string, jwsPrivateKey?: string) {
+  constructor(apiKey: string, jwsPrivateKey?: string, options?: { userAgent?: string }) {
     this.#client = new Client({
       baseUrl: `${API_BASE_URL}`,
-      userAgent: `fintoc-node/${version}`,
+      userAgent: options?.userAgent || `fintoc-node/${version}`,
       apiKey,
       jwsPrivateKey,
     });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -44,7 +44,8 @@ export function singularize(rawString: string) {
  * @returns A boolean that represents if `rawDate` is parseable as a Date object
  */
 export function isISODate(rawDate: string) {
-  return !Number.isNaN(Date.parse(rawDate));
+  const isoDateRegex = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+  return isoDateRegex.test(rawDate);
 }
 
 /**

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,3 +1,3 @@
-export const versionInfo = [1, 18, 0];
+export const versionInfo = [1, 19, 0];
 
 export const version = versionInfo.join('.');

--- a/src/spec/core.spec.ts
+++ b/src/spec/core.spec.ts
@@ -9,3 +9,17 @@ test('"Fintoc" object creation', (t) => {
   t.assert(fintoc.links instanceof LinksManager);
   t.assert(fintoc.webhookEndpoints instanceof WebhookEndpointsManager);
 });
+
+test('"Fintoc" object creation with custom userAgent', (t) => {
+  const apiKey = 'super_secret_api_key';
+  const fintoc = new Fintoc(apiKey, undefined, { userAgent: 'fintoc-cli/0.1.0' });
+  t.assert(fintoc.links instanceof LinksManager);
+  t.assert(fintoc.webhookEndpoints instanceof WebhookEndpointsManager);
+  t.is((fintoc.links as any)._client.userAgent, 'fintoc-cli/0.1.0');
+});
+
+test('"Fintoc" object creation uses default userAgent when not provided', (t) => {
+  const apiKey = 'super_secret_api_key';
+  const fintoc = new Fintoc(apiKey);
+  t.true((fintoc.links as any)._client.userAgent.startsWith('fintoc-node/'));
+});

--- a/src/spec/utils/getResourceClass.spec.ts
+++ b/src/spec/utils/getResourceClass.spec.ts
@@ -28,6 +28,12 @@ test('"getResourceClass" string resource', async (t) => {
   t.is(klass, String);
 });
 
+test('"getResourceClass" ambiguous string that Date.parse accepts should remain String', async (t) => {
+  const resource = 'any_resource';
+  t.is(await getResourceClass(resource, 'PS 2'), String);
+  t.is(await getResourceClass(resource, 'test 1'), String);
+});
+
 test('"getResourceClass" number resource', async (t) => {
   const resource = 'any_resource';
   const klass = await getResourceClass(resource, 15);

--- a/src/spec/utils/isISODate.spec.ts
+++ b/src/spec/utils/isISODate.spec.ts
@@ -7,7 +7,22 @@ test('"isISODate" valid ISO format', (t) => {
   t.assert(isISODate(validISODaTetimeString));
 });
 
+test('"isISODate" valid ISO date without time', (t) => {
+  t.assert(isISODate('2021-08-13'));
+});
+
+test('"isISODate" valid ISO date with timezone offset', (t) => {
+  t.assert(isISODate('2021-08-13T13:40:40.811+05:00'));
+});
+
 test('"isISODate" invalid ISO format', (t) => {
   const invalidISODaTetimeString = 'This is not a date';
   t.assert(!isISODate(invalidISODaTetimeString));
+});
+
+test('"isISODate" should not parse ambiguous strings as dates', (t) => {
+  t.assert(!isISODate('PS 2'));
+  t.assert(!isISODate('test 1'));
+  t.assert(!isISODate('Mar 5'));
+  t.assert(!isISODate('Jan 2024'));
 });


### PR DESCRIPTION
## Summary

Release v1.19.0 — cherry-picks the post-1.18.0 commits onto `stable`.

Includes:
- #89 feat: expose `userAgent` option in `Fintoc` constructor
- #90 fix: use strict ISO 8601 regex in `isISODate` to prevent plain strings being parsed as dates
- #91 pre-release: prepare 1.19.0 release

## Why cherry-pick instead of merging master directly

The previous release PR (#88) was squash-merged, which collapsed the v1.18.0 commits into a single new commit on `stable` (`737b163`) with no graph link to master's `13e9945`. Merging master → stable now would replay every commit since `352f867` and conflict against the squashed copy of those same changes.

This PR applies only the genuinely new commits (#89/#90/#91) on top of stable.

## Important — merge with a merge commit, NOT squash

Use **Create a merge commit** when merging this PR. That records master's tip as a parent of stable, restoring the graph link so the next release PR has a clean merge base. Squashing again will reintroduce the drift.

## Test plan

- [ ] CI passes
- [ ] Diff against `stable` shows only the three expected commits