### PR TITLE
[DX-597] migrate release to fin-releases composite action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,85 +1,58 @@
 name: release
 
 on:
-  push:
-    branches:
-      - stable
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Tipo de bump'
+        type: choice
+        required: true
+        default: minor
+        options: [patch, minor, major]
+      release-notes:
+        description: 'Release notes (markdown, opcional)'
+        type: string
+        required: false
 
 jobs:
-  npm-release:
+  release:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     permissions:
+      contents: write
       id-token: write
-      contents: read
     steps:
-      - name: Checkout to commit code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Node.js v24
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
-      - name: Set up node_modules cache
-        uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: node-modules-cache
         with:
           key: node-modules-cache-${{ hashFiles('**/yarn.lock') }}
           path: '**/node_modules'
 
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      - if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
-      - name: Build the package
-        run: yarn build
+      - run: yarn build
 
-      - name: Publish the package
-        run: npm publish
-
-  github-release:
-    needs: npm-release
-
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout to commit code
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js v24
-        uses: actions/setup-node@v4
+      - uses: fintoc-com/hermes/.github/actions/release/prepare@main
+        id: prep
         with:
-          node-version: 24
+          bump: ${{ inputs.bump }}
+          version-format: npm
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}
 
-      - name: Set up node_modules cache
-        uses: actions/cache@v3
-        id: node-modules-cache
+      - run: npm publish
+
+      - uses: fintoc-com/hermes/.github/actions/release/finalize@main
         with:
-          key: node-modules-cache-${{ hashFiles('**/yarn.lock') }}
-          path: '**/node_modules'
-
-      - name: Install dependencies
-        if: steps.node-modules-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
-
-      - name: Get version
-        id: version
-        run: echo ::set-output name=version::$(yarn --silent version:get)
-
-      - name: Get Pull Request data
-        uses: jwalton/gh-find-current-pr@v1
-        id: find-pr
-        with:
-          state: all
-
-      - name: Tag and Release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.version }}
-          release_name: ${{ steps.version.outputs.version }}
-          body: |
-            ${{ steps.find-pr.outputs.body }}
-          draft: false
-          prerelease: false
+          tag: ${{ steps.prep.outputs.tag }}
+          release-notes: ${{ inputs.release-notes }}
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,25 @@
-Releasing
-=========
+# Releasing
 
-1. From `master`, bump the package version, using `yarn bump! minor` (you can bump `patch`, `minor` or `major`).
-2. Push the new branch to `origin`.
-3. After merging the bumped version to `master`, make a Pull Request from `master` to `stable`. Make sure to include every change, using the template located at `.github/PULL_REQUEST_TEMPLATE/release.md`.
-4. Merge the Pull Request.
+Manual desde Actions. Toma ~2–3 min.
+
+## Cómo
+
+1. https://github.com/fintoc-com/fintoc-node/actions → **Release** → **Run workflow**.
+2. `bump`: `patch` / `minor` / `major`. `release-notes`: markdown opcional.
+3. **Run workflow**. Solo corre desde `master`.
+
+## Qué hace
+
+`yarn install` + `yarn build` →
+[`release/prepare`](https://github.com/fintoc-com/hermes/tree/main/.github/actions/release/prepare) bumpea local →
+`npm publish` (OIDC) →
+[`release/finalize`](https://github.com/fintoc-com/hermes/tree/main/.github/actions/release/finalize) pushea commit + tag, crea GitHub Release.
+
+Todo autoreado por `fin-releases[bot]`.
+
+## Si falla
+
+| Falla en | Estado | Recovery |
+|---|---|---|
+| Antes o durante `npm publish` | Nada en el remote | Re-run |
+| `release/finalize` (post-publish) | Paquete en npm, sin tag/release | `git push origin HEAD --follow-tags` + `gh release create vX.Y.Z` |


### PR DESCRIPTION
## Description

Reemplaza `release.yml` (push a `stable`) por un `workflow_dispatch` manual que delega bump + tag + GitHub Release a la composite action `fin-releases` de hermes. Mantiene exactamente los mismos pasos de release que hoy: `yarn install` + `yarn build` + `npm publish` (trusted publishing via `id-token`).

Ya no hay que hacer una pr de master a stable. Cuando se haga merge en master, hay que ir a la pestaña de actions y gatillar el release

Flujo:

```
release/prepare  →  npm publish  →  release/finalize
```

Inputs del dispatch: `bump` (patch/minor/major) y `release-notes` (markdown opcional).


### Diferencias vs hoy

| | Hoy | Este PR |
|---|---|---|
| Trigger | push a `stable` (via PR `master → stable`) | botón en Actions |
| Bump | manual en PR `release/prepare-X.Y.Z` | dropdown en el dispatch |
| Identidad commit/tag | `github-actions[bot]` | `fin-releases[bot]` (App) |


## Requirements
- Nada, ya tiene todo instalado

## Additional changes

Nope