### PR TITLE
[DX-586] fix: point release workflow at fintoc-com/release-action@main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,18 @@ jobs:
 
       - run: yarn build
 
-      - uses: fintoc-com/hermes/.github/actions/release/prepare@main
+      - uses: fintoc-com/release-action/prepare@main
         id: prep
         with:
           bump: ${{ inputs.bump }}
           version-format: npm
+          tag-prefix: v
           app-id: ${{ vars.FIN_RELEASES_APP_ID }}
           app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}
 
       - run: npm publish
 
-      - uses: fintoc-com/hermes/.github/actions/release/finalize@main
+      - uses: fintoc-com/release-action/finalize@main
         with:
           tag: ${{ steps.prep.outputs.tag }}
           release-notes: ${{ inputs.release-notes }}


### PR DESCRIPTION
## Description

El primer run del workflow `Release` migrado falló en *Prepare all required actions* con:

```
Unable to resolve action `fintoc-com/hermes`, not found
```

GitHub no permite que repos públicos consuman actions hospedadas en repos privados. `fintoc-com/hermes` es privado; `fintoc-node` es público → la action es inaccesible desde acá.

Las composite actions `prepare` y `finalize` se movieron al repo público https://github.com/fintoc-com/release-action. Este PR repunta los refs y agrega `tag-prefix: v` (input obligatorio).

Nota: la convención histórica de tags fue sin prefix (`1.19.0`). Migramos a `v` para alinear con el resto del ecosistema (cli, ruby, spring-ui, semver mainstream). El próximo release sale como `v1.19.1`.

## Requirements

- Nada nuevo

## Additional changes

None.