### PR TITLE
release: v1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fintoc",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "The official Node client for the Fintoc API.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
## Description

Recovery del primer run del workflow `Release` después de la migración a `fintoc-com/release-action`.

El run anterior corrió antes de que la App `fin-releases` estuviera en el bypass list de `master`. La secuencia fue:

1. `release/prepare` bumpeó `package.json` a 1.19.1 y dejó commit + tag locales ✓
2. `npm publish` publicó `fintoc@1.19.1` a npmjs ✓
3. `release/finalize` intentó `git push origin HEAD --follow-tags`:
   - El tag `v1.19.1` pasó (los tags no estaban protegidos) ✓
   - El commit fue rechazado por la regla "Require a pull request before merging" ❌

Estado tras ese run:

- `fintoc@1.19.1` en npmjs ✓
- Tag `v1.19.1` en remote (apuntando a un commit huérfano) ✓
- Commit `release: v1.19.1` no en `master` ❌
- Sin GitHub Release entry ❌

Este PR sube el commit huérfano a `master` (es fast-forward) para dejar el estado consistente. El próximo paso (manual) es `gh release create v1.19.1 --target master`.

La App ya está en el bypass list, así que el próximo release real (1.19.2 / 1.20.0) va a evitar este lío.

Linear: https://linear.app/fintoc/issue/DX-586

## Requirements

None — el commit ya existe en GitHub bajo el tag.

## Additional changes

None.