### PR TITLE
feat: add webhook test endpoint

### DIFF
--- a/src/lib/managers/webhookEndpointsManager.ts
+++ b/src/lib/managers/webhookEndpointsManager.ts
@@ -1,7 +1,16 @@
 import { ManagerMixin } from '../mixins';
 import { WebhookEndpoint } from '../resources/webhookEndpoint';
+import { WebhookEvent } from '../resources/webhookEvent';
+import { canRaiseHTTPError, objetize } from '../utils';
 
 export class WebhookEndpointsManager extends ManagerMixin<WebhookEndpoint> {
   static resource = 'webhook_endpoint';
-  static methods = ['list', 'get', 'create', 'update', 'delete'];
+  static methods = ['list', 'get', 'create', 'update', 'delete', 'test'];
+
+  @canRaiseHTTPError
+  async test(webhookEndpointId: string, args: { type: string }): Promise<WebhookEvent> {
+    const path = `${this.buildPath()}/${webhookEndpointId}/test`;
+    const data = await this._client.request({ path, method: 'post', json: args });
+    return objetize(WebhookEvent, this._client, data);
+  }
 }

--- a/src/lib/managers/webhookEndpointsManager.ts
+++ b/src/lib/managers/webhookEndpointsManager.ts
@@ -1,16 +1,12 @@
 import { ManagerMixin } from '../mixins';
 import { WebhookEndpoint } from '../resources/webhookEndpoint';
-import { WebhookEvent } from '../resources/webhookEvent';
-import { canRaiseHTTPError, objetize } from '../utils';
 
 export class WebhookEndpointsManager extends ManagerMixin<WebhookEndpoint> {
   static resource = 'webhook_endpoint';
   static methods = ['list', 'get', 'create', 'update', 'delete', 'test'];
 
-  @canRaiseHTTPError
-  async test(webhookEndpointId: string, args: { type: string }): Promise<WebhookEvent> {
+  test(webhookEndpointId: string, args: { type: string }): Promise<WebhookEndpoint> {
     const path = `${this.buildPath()}/${webhookEndpointId}/test`;
-    const data = await this._client.request({ path, method: 'post', json: args });
-    return objetize(WebhookEvent, this._client, data);
+    return this._create({ path_: path, ...args });
   }
 }

--- a/src/lib/resources/webhookEvent.ts
+++ b/src/lib/resources/webhookEvent.ts
@@ -1,3 +1,0 @@
-import { ResourceMixin } from '../mixins/resourceMixin';
-
-export class WebhookEvent extends ResourceMixin<WebhookEvent> {}

--- a/src/lib/resources/webhookEvent.ts
+++ b/src/lib/resources/webhookEvent.ts
@@ -1,0 +1,3 @@
+import { ResourceMixin } from '../mixins/resourceMixin';
+
+export class WebhookEvent extends ResourceMixin<WebhookEvent> {}

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -368,6 +368,17 @@ test('fintoc.webhookEndpoints.delete()', async (t) => {
   t.is(deletedIdentifier, webhookEndpointId);
 });
 
+test('fintoc.webhookEndpoints.test()', async (t) => {
+  const ctx: any = t.context;
+  const webhookEndpointId = 'we_example_id';
+  const eventType = 'payment_intent.succeeded';
+  const event = await ctx.fintoc.webhookEndpoints.test(webhookEndpointId, { type: eventType });
+
+  t.is(event.method, 'post');
+  t.is(event.url, `v1/webhook_endpoints/${webhookEndpointId}/test`);
+  t.is(event.json.type, eventType);
+});
+
 test('fintoc.invoices.list()', async (t) => {
   const ctx: any = t.context;
   const invoices = await ctx.fintoc.invoices.list();

--- a/src/spec/managers/webhookEndpointsManager.spec.ts
+++ b/src/spec/managers/webhookEndpointsManager.spec.ts
@@ -1,0 +1,40 @@
+import test from 'ava';
+
+import { Client } from '../../lib/client';
+import { WebhookEndpointsManager } from '../../lib/managers';
+import { WebhookEvent } from '../../lib/resources/webhookEvent';
+import { mockAxios, restore } from '../mocks/initializers';
+
+test.before((t) => {
+  const ctx: any = t.context;
+  ctx.axiosMock = mockAxios();
+});
+
+test.after((t) => {
+  const ctx: any = t.context;
+  restore(ctx.axiosMock);
+});
+
+test.beforeEach((t) => {
+  const ctx: any = t.context;
+
+  ctx.client = new Client({
+    baseUrl: 'https://test.com',
+    apiKey: 'super_secret_api_key',
+    userAgent: 'fintoc-node/test',
+  });
+  ctx.path = '/v1/webhook_endpoints';
+});
+
+test('"WebhookEndpointsManager.test" returns a WebhookEvent instance', async (t) => {
+  const ctx: any = t.context;
+  const manager = new WebhookEndpointsManager(ctx.path, ctx.client);
+
+  const event = await manager.test('we_123', { type: 'payment_intent.succeeded' });
+
+  t.true(event instanceof WebhookEvent);
+  t.is(event.id, 'we_123');
+  t.is(event.method, 'post');
+  t.is(event.url, 'v1/webhook_endpoints/we_123/test');
+  t.is(event.json.type, 'payment_intent.succeeded');
+});

--- a/src/spec/managers/webhookEndpointsManager.spec.ts
+++ b/src/spec/managers/webhookEndpointsManager.spec.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 
 import { Client } from '../../lib/client';
 import { WebhookEndpointsManager } from '../../lib/managers';
-import { WebhookEvent } from '../../lib/resources/webhookEvent';
+import { WebhookEndpoint } from '../../lib/resources/webhookEndpoint';
 import { mockAxios, restore } from '../mocks/initializers';
 
 test.before((t) => {
@@ -26,13 +26,13 @@ test.beforeEach((t) => {
   ctx.path = '/v1/webhook_endpoints';
 });
 
-test('"WebhookEndpointsManager.test" returns a WebhookEvent instance', async (t) => {
+test('"WebhookEndpointsManager.test" posts to the test endpoint', async (t) => {
   const ctx: any = t.context;
   const manager = new WebhookEndpointsManager(ctx.path, ctx.client);
 
   const event = await manager.test('we_123', { type: 'payment_intent.succeeded' });
 
-  t.true(event instanceof WebhookEvent);
+  t.true(event instanceof WebhookEndpoint);
   t.is(event.id, 'we_123');
   t.is(event.method, 'post');
   t.is(event.url, 'v1/webhook_endpoints/we_123/test');


### PR DESCRIPTION
## Description

Adds support for upcoming endpoint to send test webhook events.

## Requirements

Public API needs to be deployed to prod for this to work, still in review.


None.

## Additional changes

None.
