### PR TITLE
[TRNF-7286] Feat(v2): Add entity onboardings and multipart uploads

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "dependencies": {
     "@types/node": "^22.15.18",
-    "axios": "^1.10.0"
+    "axios": "^1.10.0",
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "@ava/typescript": "^6.0.0",

--- a/src/interfaces/client/requestOptions.ts
+++ b/src/interfaces/client/requestOptions.ts
@@ -1,4 +1,5 @@
 import { Method } from 'axios';
+import FormData from 'form-data';
 
 export interface IRequestOptions {
   path: string,
@@ -7,4 +8,5 @@ export interface IRequestOptions {
   params?: Record<string, any>,
   json?: Record<string, string>,
   idempotencyKey?: string,
+  form?: FormData,
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -108,7 +108,8 @@ export class Client {
     };
 
     if (form) {
-      // Let FormData set the multipart Content-Type (including the boundary).
+      // form-data is sent as a stream, so axios won't set the multipart
+      // Content-Type itself; replace the default JSON one with the boundary.
       delete headers['Content-Type'];
       Object.assign(headers, form.getHeaders());
     }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 
 import axios, { AxiosInstance } from 'axios';
+import FormData from 'form-data';
 
 import { IConstructorOptions } from '../interfaces/client';
 import { IExtendOptions } from '../interfaces/client/extensionOptions';
@@ -56,7 +57,7 @@ export class Client {
     options: IRequestOptions,
   ): Promise<Record<string, string> | AsyncGenerator<Record<string, string>, void, unknown>> {
     const {
-      path, json, paginated = false, method = 'get', params = {}, idempotencyKey,
+      path, json, paginated = false, method = 'get', params = {}, idempotencyKey, form,
     } = options;
     const url = `${this.baseUrl}${path}`;
     const allParams = { ...this.params, ...params };
@@ -67,6 +68,13 @@ export class Client {
         headers: this.staticHeaders,
         params: allParams,
       });
+    }
+    if (form) {
+      const headers = this.buildHeaders(method, undefined, idempotencyKey, form);
+      const response = await this.client.request({
+        method, url, params: allParams, data: form, headers,
+      });
+      return response.data;
     }
     const rawBody = JSON.stringify(json);
     const headers = this.buildHeaders(method, rawBody, idempotencyKey);
@@ -90,13 +98,20 @@ export class Client {
 
   private buildHeaders(
     method: string,
-    rawBody: string,
+    rawBody?: string,
     idempotencyKey?: string,
+    form?: FormData,
   ): Record<string, string> {
     const headers: Record<string, string> = {
       ...this.staticHeaders,
       ...this.buildJWSHeaders(method, rawBody),
     };
+
+    if (form) {
+      // Let FormData set the multipart Content-Type (including the boundary).
+      delete headers['Content-Type'];
+      Object.assign(headers, form.getHeaders());
+    }
 
     if (method === 'post') {
       headers['Idempotency-Key'] = idempotencyKey || crypto.randomUUID();
@@ -104,8 +119,9 @@ export class Client {
     return headers;
   }
 
-  private buildJWSHeaders(method: string, rawBody: string): Record<string, string> {
-    if (this.jws && (method === 'post' || method === 'put' || method === 'patch')) {
+  private buildJWSHeaders(method: string, rawBody?: string): Record<string, string> {
+    // Multipart requests are not signed; skip JWS when there is no raw JSON body.
+    if (rawBody !== undefined && this.jws && (method === 'post' || method === 'put' || method === 'patch')) {
       const signature = this.jws.generateHeader(rawBody);
       return { 'Fintoc-JWS-Signature': signature };
     }

--- a/src/lib/managers/v2/entitiesManager.ts
+++ b/src/lib/managers/v2/entitiesManager.ts
@@ -1,7 +1,17 @@
+import { Client } from '../../client';
 import { ManagerMixin } from '../../mixins';
 import { Entity } from '../../resources/v2/entity';
 
+import { OnboardingsManager } from './onboardingsManager';
+
 export class EntitiesManager extends ManagerMixin<Entity> {
   static resource = 'entity';
-  static methods = ['list', 'get'];
+  static methods = ['list', 'get', 'create'];
+
+  onboardings: OnboardingsManager;
+
+  constructor(path: string, client: Client) {
+    super(path, client);
+    this.onboardings = new OnboardingsManager('/v2/entities/{entity_id}/onboardings', client);
+  }
 }

--- a/src/lib/managers/v2/index.ts
+++ b/src/lib/managers/v2/index.ts
@@ -13,3 +13,4 @@ export * from './paymentMethodsManager';
 export * from './productsManager';
 export * from './subscriptionsManager';
 export * from './accountStatementsManager';
+export * from './onboardingsManager';

--- a/src/lib/managers/v2/onboardingsManager.ts
+++ b/src/lib/managers/v2/onboardingsManager.ts
@@ -1,0 +1,52 @@
+import { ResourceArguments, UploadFile } from '../../../types';
+import { ManagerMixin } from '../../mixins';
+import { resourceUpload } from '../../resourceHandlers';
+import { Onboarding } from '../../resources/v2/onboarding';
+import { canRaiseHTTPError, getResourceClass } from '../../utils';
+
+export class OnboardingsManager extends ManagerMixin<Onboarding> {
+  static resource = 'onboarding';
+  static methods = ['list', 'get'];
+
+  create(args?: ResourceArguments): Promise<Onboarding> {
+    const innerArgs = args || {};
+    const path = this.buildPath(innerArgs);
+    return this._create({ path_: path, ...innerArgs });
+  }
+
+  submit(id: string, args?: ResourceArguments): Promise<Onboarding> {
+    const innerArgs = args || {};
+    const path = `${this.buildPath(innerArgs)}/${id}/submit`;
+    return this._create({ path_: path, ...innerArgs });
+  }
+
+  uploadDocument(
+    id: string,
+    slotKey: string,
+    file: UploadFile,
+    args?: ResourceArguments,
+  ): Promise<Onboarding> {
+    const innerArgs = args || {};
+    const path = `${this.buildPath(innerArgs)}/${id}/documents/${slotKey}`;
+    return this.uploadFile(path, file);
+  }
+
+  uploadShareholderDocument(
+    id: string,
+    shareholderId: string,
+    file: UploadFile,
+    args?: ResourceArguments,
+  ): Promise<Onboarding> {
+    const innerArgs = args || {};
+    const path = `${this.buildPath(innerArgs)}/${id}/shareholders/${shareholderId}/document`;
+    return this.uploadFile(path, file);
+  }
+
+  @canRaiseHTTPError
+  private async uploadFile(path: string, file: UploadFile): Promise<Onboarding> {
+    const klass = await getResourceClass(
+      (this.constructor as typeof OnboardingsManager).resource,
+    );
+    return resourceUpload<Onboarding>(this._client, path, klass, file);
+  }
+}

--- a/src/lib/managers/v2/onboardingsManager.ts
+++ b/src/lib/managers/v2/onboardingsManager.ts
@@ -1,8 +1,6 @@
 import { ResourceArguments, UploadFile } from '../../../types';
 import { ManagerMixin } from '../../mixins';
-import { resourceUpload } from '../../resourceHandlers';
 import { Onboarding } from '../../resources/v2/onboarding';
-import { canRaiseHTTPError, getResourceClass } from '../../utils';
 
 export class OnboardingsManager extends ManagerMixin<Onboarding> {
   static resource = 'onboarding';
@@ -28,7 +26,7 @@ export class OnboardingsManager extends ManagerMixin<Onboarding> {
   ): Promise<Onboarding> {
     const innerArgs = args || {};
     const path = `${this.buildPath(innerArgs)}/${id}/documents/${slotKey}`;
-    return this.uploadFile(path, file);
+    return this._upload(path, file);
   }
 
   uploadShareholderDocument(
@@ -39,14 +37,6 @@ export class OnboardingsManager extends ManagerMixin<Onboarding> {
   ): Promise<Onboarding> {
     const innerArgs = args || {};
     const path = `${this.buildPath(innerArgs)}/${id}/shareholders/${shareholderId}/document`;
-    return this.uploadFile(path, file);
-  }
-
-  @canRaiseHTTPError
-  private async uploadFile(path: string, file: UploadFile): Promise<Onboarding> {
-    const klass = await getResourceClass(
-      (this.constructor as typeof OnboardingsManager).resource,
-    );
-    return resourceUpload<Onboarding>(this._client, path, klass, file);
+    return this._upload(path, file);
   }
 }

--- a/src/lib/mixins/managerMixin.ts
+++ b/src/lib/mixins/managerMixin.ts
@@ -1,5 +1,5 @@
 import { IManagerMixinConstructor, IResourceMixin } from '../../interfaces/mixins';
-import { GenericFunction, ResourceArguments } from '../../types';
+import { GenericFunction, ResourceArguments, UploadFile } from '../../types';
 import { Client } from '../client';
 import {
   resourceAll,
@@ -7,6 +7,7 @@ import {
   resourceDelete,
   resourceGet,
   resourceUpdate,
+  resourceUpload,
 } from '../resourceHandlers';
 import { canRaiseHTTPError, getResourceClass } from '../utils';
 
@@ -169,6 +170,19 @@ export abstract class ManagerMixin<ResourceType extends IResourceMixin> {
       idempotencyKey?.toString(),
     );
     return this.postCreateHandler(object, innerArgs);
+  }
+
+  @canRaiseHTTPError
+  protected async _upload(path: string, file: UploadFile): Promise<ResourceType> {
+    const klass = await getResourceClass(this.#originatingClass.resource);
+    return resourceUpload<ResourceType>(
+      this._client,
+      path,
+      klass,
+      file,
+      this.#handlers,
+      this.#originatingClass.methods,
+    );
   }
 
   @canRaiseHTTPError

--- a/src/lib/resourceHandlers.ts
+++ b/src/lib/resourceHandlers.ts
@@ -1,4 +1,6 @@
-import { GenericFunction } from '../types';
+import FormData from 'form-data';
+
+import { GenericFunction, UploadFile } from '../types';
 
 import { Client } from './client';
 import { objetize, objetizeGenerator } from './utils';
@@ -103,6 +105,41 @@ export async function resourceCreate<ResourceType>(
   const data = await client.request({
     path, method: 'post', json: params, idempotencyKey,
   });
+  return objetize(
+    klass,
+    client,
+    data,
+    handlers,
+    methods,
+    path,
+  );
+}
+
+/**
+ * Upload a file to a resource endpoint through a multipart/form-data request.
+ *
+ * @param client - The Client object passed to the retrieved object
+ * @param path - The path within the API server for the upload
+ * @param klass - Class that will wrap the instance of the resource
+ * @param file - The file descriptor to upload under the `file` form field
+ * @param handlers - The post-request handlers
+ * @param methods - An array of the methods that the object can execute
+ * @returns - An object of class `klass`
+ */
+export async function resourceUpload<ResourceType>(
+  client: Client,
+  path: string,
+  klass: any,
+  file: UploadFile,
+  handlers: Record<string, GenericFunction> = {},
+  methods: string[] = [],
+): Promise<ResourceType> {
+  const form = new FormData();
+  form.append('file', file.data, {
+    filename: file.filename,
+    contentType: file.contentType,
+  });
+  const data = await client.request({ path, method: 'put', form });
   return objetize(
     klass,
     client,

--- a/src/lib/resources/v2/index.ts
+++ b/src/lib/resources/v2/index.ts
@@ -12,3 +12,6 @@ export * from './paymentMethod';
 export * from './product';
 export * from './subscription';
 export * from './accountStatement';
+export * from './onboarding';
+export * from './onboardingShareholder';
+export * from './onboardingDocument';

--- a/src/lib/resources/v2/onboarding.ts
+++ b/src/lib/resources/v2/onboarding.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class Onboarding extends ResourceMixin<Onboarding> {
+}

--- a/src/lib/resources/v2/onboardingDocument.ts
+++ b/src/lib/resources/v2/onboardingDocument.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class OnboardingDocument extends ResourceMixin<OnboardingDocument> {
+}

--- a/src/lib/resources/v2/onboardingShareholder.ts
+++ b/src/lib/resources/v2/onboardingShareholder.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class OnboardingShareholder extends ResourceMixin<OnboardingShareholder> {
+}

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -1424,6 +1424,126 @@ test('fintoc.v2.products.create()', async (t) => {
   t.is(product.json.currency, productData.currency);
 });
 
+test('fintoc.v2.entities.onboardings is wired', (t) => {
+  const ctx: any = t.context;
+  t.truthy(ctx.fintoc.v2.entities.onboardings);
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.list, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.get, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.create, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.submit, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.uploadDocument, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.uploadShareholderDocument, 'function');
+});
+
+test('fintoc.v2.entities.onboardings.list()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardings = await ctx.fintoc.v2.entities.onboardings.list({
+    entity_id: entityId,
+  });
+
+  let count = 0;
+  for await (const onboarding of onboardings) {
+    count += 1;
+    t.is(onboarding.method, 'get');
+    t.is(onboarding.url, `v2/entities/${entityId}/onboardings`);
+    t.is(onboarding.params.entity_id, entityId);
+  }
+
+  t.true(count > 0);
+});
+
+test('fintoc.v2.entities.onboardings.get()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardingId = 'onb_12345';
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.get(onboardingId, {
+    entity_id: entityId,
+  });
+
+  t.is(onboarding.method, 'get');
+  t.is(onboarding.url, `v2/entities/${entityId}/onboardings/${onboardingId}`);
+  t.is(onboarding.params.entity_id, entityId);
+});
+
+test('fintoc.v2.entities.onboardings.create()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardingData = {
+    entity_id: entityId,
+    company_information: { legal_name: 'ACME SpA' },
+    legal_representative: { first_name: 'Jane', last_name: 'Doe' },
+    transactional_profile: {
+      resource_origins: ['sales'],
+      monthly_amount_range: '0-1000',
+      monthly_operations_range: '0-10',
+    },
+    shareholders: [
+      {
+        type: 'natural_person', name: 'Jane', last_name: 'Doe', holder_id: 'h1', nationality: 'CL', percentage: 100,
+      },
+    ],
+  };
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.create(onboardingData);
+
+  t.is(onboarding.method, 'post');
+  t.is(onboarding.url, `v2/entities/${entityId}/onboardings`);
+  t.is(onboarding.json.company_information.legal_name, 'ACME SpA');
+  t.is(onboarding.json.legal_representative.first_name, 'Jane');
+  t.deepEqual(onboarding.json.transactional_profile.resource_origins, ['sales']);
+});
+
+test('fintoc.v2.entities.onboardings.submit()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardingId = 'onb_12345';
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.submit(onboardingId, {
+    entity_id: entityId,
+  });
+
+  t.is(onboarding.method, 'post');
+  t.is(onboarding.url, `v2/entities/${entityId}/onboardings/${onboardingId}/submit`);
+});
+
+test('fintoc.v2.entities.onboardings.uploadDocument()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardingId = 'onb_12345';
+  const slotKey = 'tax_registration_certificate';
+  const file = { data: Buffer.from('fake pdf'), filename: 'cert.pdf', contentType: 'application/pdf' };
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.uploadDocument(
+    onboardingId,
+    slotKey,
+    file,
+    { entity_id: entityId },
+  );
+
+  t.is(onboarding.method, 'put');
+  t.is(onboarding.url, `v2/entities/${entityId}/onboardings/${onboardingId}/documents/${slotKey}`);
+  t.true(onboarding.multipart);
+});
+
+test('fintoc.v2.entities.onboardings.uploadShareholderDocument()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_12345';
+  const onboardingId = 'onb_12345';
+  const shareholderId = 'onbsh_abcd';
+  const file = { data: Buffer.from('fake pdf'), filename: 'id.pdf', contentType: 'application/pdf' };
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.uploadShareholderDocument(
+    onboardingId,
+    shareholderId,
+    file,
+    { entity_id: entityId },
+  );
+
+  t.is(onboarding.method, 'put');
+  t.is(
+    onboarding.url,
+    `v2/entities/${entityId}/onboardings/${onboardingId}/shareholders/${shareholderId}/document`,
+  );
+  t.true(onboarding.multipart);
+});
+
 test('fintoc.apiKeys.list()', async (t) => {
   const ctx: any = t.context;
   const apiKeys = await ctx.fintoc.apiKeys.list();

--- a/src/spec/mocks/client/axiosInstance.ts
+++ b/src/spec/mocks/client/axiosInstance.ts
@@ -30,12 +30,14 @@ export class MockAxiosInstance extends Axios {
     const innerParams = Object.fromEntries(query.map((x) => x.split('=')));
     const completeParams = { ...innerParams, ...(params === undefined ? {} : params) };
     const usableURL = url?.split('//').slice(-1)[0].split('/').slice(1).join('/').split('?')[0] || '';
+    const isMultipart = data !== undefined && typeof data !== 'string';
     return new MockResponse({
       method: usingMethod,
       baseURL: usingBaseURL,
       url: usableURL,
       params: completeParams,
-      json: JSON.parse(data || '{}'),
+      json: isMultipart ? {} : JSON.parse(data || '{}'),
+      multipart: isMultipart,
       headers: headers || {},
     });
   }

--- a/src/spec/mocks/client/axiosInstance.ts
+++ b/src/spec/mocks/client/axiosInstance.ts
@@ -1,4 +1,5 @@
 import { Axios, AxiosRequestConfig } from 'axios';
+import FormData from 'form-data';
 
 import { MockResponse } from './response';
 
@@ -30,7 +31,7 @@ export class MockAxiosInstance extends Axios {
     const innerParams = Object.fromEntries(query.map((x) => x.split('=')));
     const completeParams = { ...innerParams, ...(params === undefined ? {} : params) };
     const usableURL = url?.split('//').slice(-1)[0].split('/').slice(1).join('/').split('?')[0] || '';
-    const isMultipart = data !== undefined && typeof data !== 'string';
+    const isMultipart = data instanceof FormData;
     return new MockResponse({
       method: usingMethod,
       baseURL: usingBaseURL,

--- a/src/spec/mocks/client/response.ts
+++ b/src/spec/mocks/client/response.ts
@@ -6,15 +6,17 @@ export class MockResponse {
   url: string;
   json: Record<string, any> | undefined;
   requestHeaders: Record<string, any>;
+  multipart: boolean;
 
   constructor(config: Record<string, any>) {
     const {
-      method, baseURL, url, params, json, headers,
+      method, baseURL, url, params, json, headers, multipart,
     } = config;
 
     this.baseURL = baseURL;
     this.params = params;
     this.requestHeaders = headers || {};
+    this.multipart = multipart || false;
 
     let page;
     if (method === 'get' && url.charAt(url.length - 1) === 's') {
@@ -54,6 +56,7 @@ export class MockResponse {
       params: this.params,
       json: this.json,
       headers: this.requestHeaders,
+      multipart: this.multipart,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './genericFunction';
 export * from './resourceArguments';
+export * from './uploadFile';

--- a/src/types/uploadFile.ts
+++ b/src/types/uploadFile.ts
@@ -1,0 +1,8 @@
+/**
+ * Descriptor for a file to be sent through a multipart/form-data request.
+ */
+export interface UploadFile {
+  data: Buffer | NodeJS.ReadableStream | Blob;
+  filename: string;
+  contentType?: string;
+}


### PR DESCRIPTION
## Contexto

Soporte en el SDK para el nuevo flujo de onboarding de entities de la API pública v2 (`/v2/entities/{id}/onboardings`).

## Qué hay de nuevo?

- Se exponen los siguientes endpoints para el proceso de onboarding de entities:
  - `POST /v2/entities`
  - `POST /v2/entities/{id}/onboardings`
  - `PUT /v2/entities/{id}/onboardings/{id}/shareholders/{id}/document`
  - `PUT /v2/entities/{id}/onboardings/{id}/documents/{slot_key}`
  - `POST /v2/entities/{id}/onboardings/{id}/submit`
- Se agrega soporte de `multipart/form-data` en el cliente HTTP.

## Tests

Unitarios para el cliente multipart, los recursos y el manager (incluyendo las subidas de documentos). Probado end-to-end localmente contra fintoc-rails + pacioli (crear onboarding → subir documentos → submit).

## Consideraciones

Las subidas multipart no se firman con JWS.

## Rollback
¿Es seguro hacer rollback?
Sí

¿Cuáles son los pasos para hacer rollback?
Normal
