### PR TITLE
[ONB-2512] Feat(v2): Add legal representative document upload

### DIFF
--- a/src/lib/managers/v2/onboardingsManager.ts
+++ b/src/lib/managers/v2/onboardingsManager.ts
@@ -39,4 +39,16 @@ export class OnboardingsManager extends ManagerMixin<Onboarding> {
     const path = `${this.buildPath(innerArgs)}/${id}/shareholders/${shareholderId}/document`;
     return this._upload(path, file);
   }
+
+  uploadLegalRepresentativeDocument(
+    id: string,
+    legalRepresentativeId: string,
+    slotKey: string,
+    file: UploadFile,
+    args?: ResourceArguments,
+  ): Promise<Onboarding> {
+    const innerArgs = args || {};
+    const path = `${this.buildPath(innerArgs)}/${id}/legal_representatives/${legalRepresentativeId}/documents/${slotKey}`;
+    return this._upload(path, file);
+  }
 }

--- a/src/lib/resources/v2/index.ts
+++ b/src/lib/resources/v2/index.ts
@@ -16,4 +16,5 @@ export * from './subscriptionItem';
 export * from './accountStatement';
 export * from './onboarding';
 export * from './onboardingShareholder';
+export * from './onboardingLegalRepresentative';
 export * from './onboardingDocument';

--- a/src/lib/resources/v2/onboardingLegalRepresentative.ts
+++ b/src/lib/resources/v2/onboardingLegalRepresentative.ts
@@ -1,0 +1,4 @@
+import { ResourceMixin } from '../../mixins/resourceMixin';
+
+export class OnboardingLegalRepresentative extends ResourceMixin<OnboardingLegalRepresentative> {
+}

--- a/src/spec/integration.spec.ts
+++ b/src/spec/integration.spec.ts
@@ -1534,6 +1534,7 @@ test('fintoc.v2.entities.onboardings is wired', (t) => {
   t.is(typeof ctx.fintoc.v2.entities.onboardings.submit, 'function');
   t.is(typeof ctx.fintoc.v2.entities.onboardings.uploadDocument, 'function');
   t.is(typeof ctx.fintoc.v2.entities.onboardings.uploadShareholderDocument, 'function');
+  t.is(typeof ctx.fintoc.v2.entities.onboardings.uploadLegalRepresentativeDocument, 'function');
 });
 
 test('fintoc.v2.entities.onboardings.list()', async (t) => {
@@ -1573,7 +1574,16 @@ test('fintoc.v2.entities.onboardings.create()', async (t) => {
   const onboardingData = {
     entity_id: entityId,
     company_information: { legal_name: 'ACME SpA' },
-    legal_representative: { first_name: 'Jane', last_name: 'Doe' },
+    legal_representatives: [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jane@acme.com',
+        nationality: 'cl',
+        identification_number: '12.345.678-9',
+        position: 'Director General',
+      },
+    ],
     transactional_profile: {
       resource_origins: ['sales'],
       monthly_amount_range: '0-1000',
@@ -1590,7 +1600,7 @@ test('fintoc.v2.entities.onboardings.create()', async (t) => {
   t.is(onboarding.method, 'post');
   t.is(onboarding.url, `v2/entities/${entityId}/onboardings`);
   t.is(onboarding.json.company_information.legal_name, 'ACME SpA');
-  t.is(onboarding.json.legal_representative.first_name, 'Jane');
+  t.is(onboarding.json.legal_representatives[0].first_name, 'Jane');
   t.deepEqual(onboarding.json.transactional_profile.resource_origins, ['sales']);
 });
 
@@ -1641,6 +1651,29 @@ test('fintoc.v2.entities.onboardings.uploadShareholderDocument()', async (t) => 
   t.is(
     onboarding.url,
     `v2/entities/${entityId}/onboardings/${onboardingId}/shareholders/${shareholderId}/document`,
+  );
+  t.true(onboarding.multipart);
+});
+
+test('fintoc.v2.entities.onboardings.uploadLegalRepresentativeDocument()', async (t) => {
+  const ctx: any = t.context;
+  const entityId = 'ent_8anBwgZktbZH6ydyHa6Tm0eM';
+  const onboardingId = 'onbprc_0ujsswThIGTUYm2K8FjOOfXtY1K';
+  const legalRepresentativeId = 'onblr_0ujsswThIGTUYm2K8FjOOfXtY1K';
+  const slotKey = 'identification';
+  const file = { data: Buffer.from('fake pdf'), filename: 'id.pdf', contentType: 'application/pdf' };
+  const onboarding = await ctx.fintoc.v2.entities.onboardings.uploadLegalRepresentativeDocument(
+    onboardingId,
+    legalRepresentativeId,
+    slotKey,
+    file,
+    { entity_id: entityId },
+  );
+
+  t.is(onboarding.method, 'put');
+  t.is(
+    onboarding.url,
+    `v2/entities/${entityId}/onboardings/${onboardingId}/legal_representatives/${legalRepresentativeId}/documents/${slotKey}`,
   );
   t.true(onboarding.multipart);
 });


### PR DESCRIPTION
## Description

Adds support for the new v2 legal representative document upload endpoint:

- `PUT /v2/entities/{entity_id}/onboardings/{onboarding_id}/legal_representatives/{legal_representative_id}/documents/{slot_key}`

Also adds the `OnboardingLegalRepresentative` resource class for the `legal_representatives` array that the API now returns on the onboarding object, mirroring how `OnboardingShareholder` is modeled.

## Requirements

None.

## Additional changes

The onboarding create integration test now sends `legal_representatives` as an array, matching the API's current request shape (the singular `legal_representative` object no longer exists).